### PR TITLE
[NDD-379] 문제집 세트 페이지에서 문제가 없는 문제집들을 client에서 막아야함 (1.5h/2h)

### DIFF
--- a/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
+++ b/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
@@ -12,6 +12,7 @@ import QuestionTabPanelHeader from '@common/QuestionSelectionBox/QuestionTabPane
 import useTabs from '@foundation/Tabs/useTabs';
 import QuestionAccordionList from '@common/QuestionSelectionBox/QuestionAccordionList';
 import useBreakpoint from '@hooks/useBreakPoint';
+import { toast } from '@foundation/Toast/toast';
 
 type TabPanelItemProps = {
   tabIndex: string;
@@ -69,7 +70,11 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({
           workbook={workbook}
           questionLength={questionData?.length || 0}
           onWorkbookDelete={() => setCurrentValue('0')}
-          onEditButtonClick={() => setIsEditMode(true)}
+          onEditButtonClick={() =>
+            questionData?.length
+              ? setIsEditMode(true)
+              : toast.info('문제가 존재하지 않습니다.')
+          }
         />
         <div
           css={css`

--- a/src/components/common/QuestionSelectionBox/WorkbookGeneratorModal/WorkbookAddForm.tsx
+++ b/src/components/common/QuestionSelectionBox/WorkbookGeneratorModal/WorkbookAddForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, InputArea } from '@foundation/index';
+import { Button, Input, InputArea, Tooltip } from '@foundation/index';
 import { css } from '@emotion/react';
 import { FormEventHandler, useState } from 'react';
 import LabelBox from '@common/QuestionSelectionBox/WorkbookGeneratorModal/LabelBox';
@@ -7,8 +7,9 @@ import useInput from '@hooks/useInput';
 import { theme } from '@styles/theme';
 import useCategoryQuery from '@hooks/apis/queries/useCategoryQuery';
 import useWorkbookAdd from '@hooks/useWorkbookAdd';
-import { ShareRangeToggle } from '@common/index';
 import { toast } from '@foundation/Toast/toast';
+import ShareRangeToggle from '@common/ShareRangeToggle/ShareRangeToggle';
+
 type WorkbookAddFormProps = {
   closeModal: () => void;
 };
@@ -16,7 +17,6 @@ const WorkbookAddForm: React.FC<WorkbookAddFormProps> = ({ closeModal }) => {
   const { data: categories } = useCategoryQuery();
   const [activeValidationError, setActiveValidationError] = useState(false);
   const [selectedCategoryIndex, setSelectedCategoryIndex] = useState(0);
-  const [isPublic, setIsPublic] = useState(true);
   const {
     value: workbookTitle,
     onChange: handleWorkbookTitleChange,
@@ -61,7 +61,7 @@ const WorkbookAddForm: React.FC<WorkbookAddFormProps> = ({ closeModal }) => {
       title: workbookTitle,
       content: workbookContent,
       categoryId: selectedCategoryId,
-      isPublic: isPublic,
+      isPublic: false,
     });
 
     toast.success('성공적으로 문제집이 추가되었습니다.');
@@ -111,14 +111,22 @@ const WorkbookAddForm: React.FC<WorkbookAddFormProps> = ({ closeModal }) => {
         />
       </LabelBox>
       <LabelBox labelName="공개 범위">
-        <ShareRangeToggle
-          isPublic={isPublic}
-          onClick={() => setIsPublic((prev) => !prev)}
-          publicText={{
-            text: '곰터뷰의 모든 사용자',
-            description: '비회원을 포함한 곰터뷰의 모든 사용자에게 공개됩니다.',
-          }}
-        />
+        <Tooltip
+          title={'문제를 추가하여 공개로 전환할 수 있습니다.'}
+          position="bottom"
+        >
+          <ShareRangeToggle
+            isPublic={false}
+            onClick={() =>
+              toast.info('문제가 존재하지 않아 공개로 전환할 수 없습니다.')
+            }
+            publicText={{
+              text: '곰터뷰의 모든 사용자',
+              description:
+                '비회원을 포함한 곰터뷰의 모든 사용자에게 공개됩니다.',
+            }}
+          />
+        </Tooltip>
       </LabelBox>
       <LabelBox labelName="설명">
         <InputArea

--- a/src/components/common/QuestionSelectionBox/WorkbookGeneratorModal/WorkbookAddForm.tsx
+++ b/src/components/common/QuestionSelectionBox/WorkbookGeneratorModal/WorkbookAddForm.tsx
@@ -8,11 +8,12 @@ import { theme } from '@styles/theme';
 import useCategoryQuery from '@hooks/apis/queries/useCategoryQuery';
 import useWorkbookAdd from '@hooks/useWorkbookAdd';
 import { toast } from '@foundation/Toast/toast';
-import ShareRangeToggle from '@common/ShareRangeToggle/ShareRangeToggle';
+import { ShareRangeToggle } from '@common/index';
 
 type WorkbookAddFormProps = {
   closeModal: () => void;
 };
+
 const WorkbookAddForm: React.FC<WorkbookAddFormProps> = ({ closeModal }) => {
   const { data: categories } = useCategoryQuery();
   const [activeValidationError, setActiveValidationError] = useState(false);

--- a/src/components/common/QuestionSelectionBox/WorkbookGeneratorModal/WorkbookEditForm.tsx
+++ b/src/components/common/QuestionSelectionBox/WorkbookGeneratorModal/WorkbookEditForm.tsx
@@ -10,6 +10,7 @@ import useCategoryQuery from '@hooks/apis/queries/useCategoryQuery';
 import useWorkbookEdit from '@hooks/useWorkbookEdit';
 import { ShareRangeToggle } from '@common/index';
 import { toast } from '@foundation/Toast/toast';
+import useQuestionWorkbookQuery from '@hooks/apis/queries/useQuestionWorkbookQuery';
 
 type WorkbookEditFormProps = {
   workbookId: number;
@@ -35,6 +36,11 @@ const WorkbookEditForm: React.FC<WorkbookEditFormProps> = ({
   } = useInput<HTMLInputElement>(workbookInfo?.title ?? '');
   const { value: workbookContent, onChange: handleWorkbookContentChange } =
     useInput<HTMLTextAreaElement>(workbookInfo?.content ?? '');
+
+  const { data: questions } = useQuestionWorkbookQuery({
+    workbookId: workbookId,
+    enabled: true,
+  });
 
   const findCategoryIndex = useCallback(
     (categoryId?: number) => {
@@ -64,6 +70,16 @@ const WorkbookEditForm: React.FC<WorkbookEditFormProps> = ({
 
   const handleCategoryClick = (index: number) => {
     setSelectedCategoryIndex(index);
+  };
+
+  const handleWorkbookIsPublic = () => {
+    if (questions && questions.length > 0) {
+      setIsPublic((prev) => !prev);
+    } else {
+      toast.info(
+        '현재 문제집에 질문이 존재하지 않아 상태 변경이 불가능합니다.'
+      );
+    }
   };
 
   const handleSubmit: FormEventHandler = (e) => {
@@ -123,7 +139,7 @@ const WorkbookEditForm: React.FC<WorkbookEditFormProps> = ({
       <LabelBox labelName="공개 범위">
         <ShareRangeToggle
           isPublic={isPublic}
-          onClick={() => setIsPublic((prev) => !prev)}
+          onClick={handleWorkbookIsPublic}
           publicText={{
             text: '곰터뷰의 모든 사용자',
             description: '비회원을 포함한 곰터뷰의 모든 사용자에게 공개됩니다.',

--- a/src/components/interviewVideoPage/ShareRangeModal/VideoShareModal.tsx
+++ b/src/components/interviewVideoPage/ShareRangeModal/VideoShareModal.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import Modal from '@foundation/Modal';
 import { Typography } from '@foundation/index';
 import useToggleVideoPublicMutation from '@hooks/apis/mutations/useToggleVideoPublicMutation';
-import ShareRangeToggle from '@common/ShareRangeToggle/ShareRangeToggle';
+import { ShareRangeToggle } from '@common/index';
 import VideoShareModalFooter from './VideoShareModalFooter';
 
 type VideoShareModalProps = {

--- a/src/hooks/useWorkbookQuestionDelete.ts
+++ b/src/hooks/useWorkbookQuestionDelete.ts
@@ -42,11 +42,7 @@ const useWorkbookQuestionDelete = (workbookId: number) => {
         return deleteQuestionAsync(questionId);
       })
     );
-    if (
-      workbookInfo &&
-      workbookInfo.isPublic &&
-      questions?.length === checkedQuestion.length
-    ) {
+    if (workbookInfo && questions?.length === checkedQuestion.length) {
       editWorkbook({
         workbookId: workbookId,
         title: workbookInfo.title,


### PR DESCRIPTION
[![NDD-379](https://badgen.net/badge/JIRA/NDD-379/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-379) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

테스트를 진행하는 유저들이 문제집을 생산하면서, 문제가 없는 문제집이 생성되고 있습니다.
이를 모두 필터링하여 BE에서 처리하는것은 매우 비효율적이므로, 이를 생성단계 혹은 수정단계에서 client에서 해결하도록 합니다.


# How

문제집의 상태를 조절해야만 하는 순간은 다음과 같습니다.

### 1. 문제집을 생성할 당시
문제집의 내부 문제가 존재하지 않으므로, 해당 문제집은 비활성화 되는것이 옳습니다. 
하지만 toggle은 남겨두면서 유저가 활성화가 가능하다는것을 인지하도록 합니다.

### 2. 문제집의 상태를 변경할 때
문제집의 내부 문제가 존재하는지를 확인하여, toggle의 상태를 조절하도록 합니다.
이를 통해서 문제집의 문제가 존재할 때만 해당 문제집을 활성화 할 수 있도록 합니다.

### 3. 문제집의 모든 문제를 삭제할 때
여기가 우선 고민이었습니다만, BE 에서 삭제 로직마다, 해당 문제가 모두 비어있는지 확인하는것은 비효율적이라 판단, 이를  client에서 해결하려합니다.
그에 따라 모든 문제가 제거되는 동작이 수행되었을때만, client에서는 해당 문제집을 비활성화 하는 기능을 수행합니다.

# Result


https://github.com/the-NDD/Gomterview-FE/assets/77886826/84aef1bd-2ae5-441b-ae6a-5bc14d65f2ca


https://github.com/the-NDD/Gomterview-FE/assets/77886826/4a1a0a98-63ee-4d7b-87b3-f23eec5951b3


https://github.com/the-NDD/Gomterview-FE/assets/77886826/bec3216b-c9db-48a4-9228-3101bd704354

[NDD-379]: https://milk717.atlassian.net/browse/NDD-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ