### PR TITLE
[NDD-400] progress bar 현재 페이지 깜빡임 추가 및 chip 컴포넌트 추가 (2h/2h)

### DIFF
--- a/src/components/common/ProgressStepBar/ProgressStepBarItem.tsx
+++ b/src/components/common/ProgressStepBar/ProgressStepBarItem.tsx
@@ -1,16 +1,30 @@
 import Typography from '@/components/foundation/Typography/Typography';
 import { theme } from '@/styles/theme';
 import { HTMLElementTypes } from '@/types/utils';
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 
 type ProgressStepBarItemProps = {
   name?: string;
   isCompleted?: boolean;
+  isCurrent?: boolean;
 } & HTMLElementTypes<HTMLDivElement>;
+
+const blink = keyframes`
+  0% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.9;
+  }
+  100%{
+    opacity: 0.3;
+  }
+`;
 
 const ProgressStepBarItem: React.FC<ProgressStepBarItemProps> = ({
   name,
   isCompleted,
+  isCurrent,
 }) => {
   return (
     <div
@@ -23,10 +37,15 @@ const ProgressStepBarItem: React.FC<ProgressStepBarItemProps> = ({
         css={css`
           height: 0.625rem;
           border-radius: 1.25rem;
-          background-color: ${isCompleted
+          background-color: ${isCompleted || isCurrent
             ? theme.colors.point.primary.default
             : theme.colors.surface.weak};
           margin-bottom: 1rem;
+          animation: ${isCurrent
+            ? css`
+                ${blink} 1s linear infinite
+              `
+            : 'none'};
         `}
       ></div>
       <Typography>{name}</Typography>

--- a/src/components/foundation/Chip/Chip.tsx
+++ b/src/components/foundation/Chip/Chip.tsx
@@ -1,0 +1,83 @@
+import { NestedObjectKey } from '@/types/utils';
+import { Theme } from '@emotion/react';
+import { css, useTheme } from '@emotion/react';
+import React from 'react';
+
+const ChipMap = (theme: Theme) => {
+  return {
+    outlined: {
+      primary: css`
+        background-color: ${theme.colors.surface.default};
+        border: 1px solid ${theme.colors.point.primary.default};
+      `,
+      secondary: css`
+        background-color: ${theme.colors.surface.default};
+        border: 1px solid ${theme.colors.point.secondary.default};
+      `,
+      tertiary: css`
+        background-color: ${theme.colors.surface.default};
+        border: 1px solid ${theme.colors.point.tertiary.default};
+      `,
+      error: css`
+        background-color: ${theme.colors.surface.default};
+        border: 1px solid ${theme.colors.point.error.default};
+      `,
+      warning: css`
+        background-color: ${theme.colors.surface.default};
+        border: 1px solid ${theme.colors.point.warning.default};
+      `,
+    },
+    contained: {
+      primary: css`
+        background-color: ${theme.colors.point.primary.default};
+        color: ${theme.colors.text.white};
+      `,
+      secondary: css`
+        background-color: ${theme.colors.point.secondary.default};
+        color: ${theme.colors.text.white};
+      `,
+      tertiary: css`
+        background-color: ${theme.colors.point.tertiary.default};
+        color: ${theme.colors.text.white};
+      `,
+      error: css`
+        background-color: ${theme.colors.point.error.default};
+        color: ${theme.colors.text.white};
+      `,
+      warning: css`
+        background-color: ${theme.colors.point.warning.default};
+        color: ${theme.colors.text.white};
+      `,
+    },
+  } as const;
+};
+
+type ChipProps = {
+  color?: NestedObjectKey<ReturnType<typeof ChipMap>>;
+  variant?: keyof ReturnType<typeof ChipMap>;
+  children: React.ReactNode;
+};
+
+const Chip: React.FC<ChipProps> = ({
+  children,
+  variant = 'contained',
+  color = 'primary' as const,
+}) => {
+  const theme = useTheme();
+
+  return (
+    <div
+      css={[
+        css`
+          padding: 0.8rem;
+          border-radius: 1rem;
+        `,
+        ChipMap(theme)[variant][color],
+      ]}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Chip;

--- a/src/page/interviewSettingPage/index.tsx
+++ b/src/page/interviewSettingPage/index.tsx
@@ -120,8 +120,9 @@ const InterviewSettingPage: React.FC = () => {
             <ProgressStepBar.Item
               key={item.name}
               name={item.name}
-              isCompleted={item.state.isSuccess || currentPage === item.path}
-            ></ProgressStepBar.Item>
+              isCurrent={currentPage === item.path}
+              isCompleted={item.state.isSuccess}
+            />
           ))}
         </ProgressStepBar>
       </div>

--- a/src/styles/_colors.ts
+++ b/src/styles/_colors.ts
@@ -101,6 +101,18 @@ export const colors = {
       default: colorChips.navy500, // #475595
       hover: colorChips.navy600, //#3C477D
     },
+    tertiary: {
+      default: colorChips.green500, // #76D773
+      hover: colorChips.green600, //#63B561
+    },
+    error: {
+      default: colorChips.red500, // #E05241
+      hover: colorChips.red600, //#BC4537
+    },
+    warning: {
+      default: colorChips.yellow500, // #EAC645
+      hover: colorChips.yellow600, //#C5A63A
+    },
   },
   status: {
     active: colorChips.green500, // #76D773

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -10,3 +10,7 @@ export type FunctionParamsType<T> = T extends (...args: infer P) => unknown
   : never;
 
 export type ExcludeArray<T> = T extends Array<infer U> ? U : T;
+
+export type NestedObjectKey<T> = T extends Record<string, infer U>
+  ? keyof U
+  : never;


### PR DESCRIPTION
[![NDD-400](https://badgen.net/badge/JIRA/NDD-400/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-400) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

설정 페이지에서 현재 페이지가 어디인지 알 수 없을거 같아서 현재 페이지는 깜빡이도록 하는 애니메이션을 추가하였습니다.
그런데 이걸 하니까 시간이 많이 남더라고요 그래서 다음 작업에 필요한 chip 컴포넌트 까지 추가하였습니다.

# How

chip 같은 경우 다양한 색상이 필요한데 지금 테마에서는 2개의 색상 밖에 없으므로 임의로 테마 색을 추가하였습니다.

```typescript
export type NestedObjectKey<T> = T extends Record<string, infer U>
  ? keyof U
  : never;

```

object에 있는 nested된 key의 값을 가져오는 util타입을 만들었습니다. 

# Result

![image](https://github.com/the-NDD/Gomterview-FE/assets/49224104/24ff4b1b-ae65-401d-820a-ad7017231302)

[NDD-400]: https://milk717.atlassian.net/browse/NDD-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ