### PR TITLE
[NDD-380] 마이페이지 영상 삭제 이슈 해결 (1h/2h)

### DIFF
--- a/src/components/myPage/MyPageTabs.tsx
+++ b/src/components/myPage/MyPageTabs.tsx
@@ -4,6 +4,9 @@ import QuestionSelectTabPanel from './TabPanel/QuestionSelectTabPanel';
 import VideoListTabPanel from './TabPanel/VideoListTabPanel';
 import { useLocation } from 'react-router-dom';
 import { Location } from '@remix-run/router';
+import { Suspense } from 'react';
+import { LoadingBounce } from '@common/index';
+import { CenterLayout } from '@components/layout';
 
 const MyPageTabs: React.FC = () => {
   const location = useLocation() as Location<{ tabIndex: string }>;
@@ -54,7 +57,15 @@ const MyPageTabs: React.FC = () => {
         <QuestionSelectTabPanel />
       </Tabs.TabPanel>
       <Tabs.TabPanel value="2">
-        <VideoListTabPanel />
+        <Suspense
+          fallback={
+            <CenterLayout>
+              <LoadingBounce />
+            </CenterLayout>
+          }
+        >
+          <VideoListTabPanel />
+        </Suspense>
       </Tabs.TabPanel>
     </Tabs>
   );

--- a/src/components/myPage/TabPanel/VideoListTabPanel.tsx
+++ b/src/components/myPage/TabPanel/VideoListTabPanel.tsx
@@ -38,8 +38,6 @@ const VideoListTabPanel: React.FC = () => {
     closeDeleteCheckModal();
   };
 
-  if (!data) return <div>로딩중</div>;
-
   return (
     <Box
       css={css`

--- a/src/components/myPage/TabPanel/VideoListTabPanel.tsx
+++ b/src/components/myPage/TabPanel/VideoListTabPanel.tsx
@@ -14,12 +14,9 @@ import { ExcludeArray } from '@/types/utils';
 
 type VideoListItemProps = {
   video: ExcludeArray<VideoListResDto>;
-  deleteVideo: (id: number) => void;
 };
-const VideoListItem: React.FC<VideoListItemProps> = ({
-  video,
-  deleteVideo,
-}) => {
+const VideoListItem: React.FC<VideoListItemProps> = ({ video }) => {
+  const { mutate } = useDeleteVideoMutation();
   const { openModal: openDeleteCheckModal, closeModal: closeDeleteCheckModal } =
     useModal(() => {
       return (
@@ -33,7 +30,7 @@ const VideoListItem: React.FC<VideoListItemProps> = ({
 
   const handleConfirmModal = () => {
     closeDeleteCheckModal();
-    deleteVideo(video.id);
+    mutate(video.id);
   };
 
   return (
@@ -55,7 +52,6 @@ const VideoListItem: React.FC<VideoListItemProps> = ({
 
 const VideoListTabPanel: React.FC = () => {
   const { data } = useVideoListQuery();
-  const { mutate } = useDeleteVideoMutation();
 
   return (
     <Box
@@ -72,7 +68,7 @@ const VideoListTabPanel: React.FC = () => {
       `}
     >
       {data.map((video) => (
-        <VideoListItem key={video.id} video={video} deleteVideo={mutate} />
+        <VideoListItem key={video.id} video={video} />
       ))}
     </Box>
   );

--- a/src/hooks/apis/mutations/useDeleteVideoMutation.ts
+++ b/src/hooks/apis/mutations/useDeleteVideoMutation.ts
@@ -1,6 +1,7 @@
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteVideoById } from '@/apis/video';
+import { VideoListResDto } from '@/types/video';
 
 /**
  * DELETE /video/${videoId}
@@ -15,6 +16,22 @@ const useDeleteVideoMutation = () => {
       void queryClient.invalidateQueries({
         queryKey: QUERY_KEY.VIDEO,
       });
+    },
+    onMutate: (videoId) => {
+      const previousVideoList = queryClient.getQueryData<VideoListResDto>(
+        QUERY_KEY.VIDEO
+      );
+      queryClient.setQueryData<VideoListResDto>(
+        QUERY_KEY.VIDEO,
+        (oldVideoList) => {
+          return oldVideoList?.filter((video) => video.id !== videoId);
+        }
+      );
+
+      return { previousVideoList };
+    },
+    onError: (_, __, context) => {
+      queryClient.setQueryData(QUERY_KEY.VIDEO, context?.previousVideoList);
     },
   });
 };

--- a/src/hooks/apis/queries/useVideoListQuery.ts
+++ b/src/hooks/apis/queries/useVideoListQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getVideoList } from '@/apis/video';
 
@@ -10,7 +10,7 @@ import { getVideoList } from '@/apis/video';
  * 마이페이지에서 사용됩니다.
  */
 const useVideoListQuery = () => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: QUERY_KEY.VIDEO,
     queryFn: () => getVideoList(),
   });


### PR DESCRIPTION
[![NDD-380](https://badgen.net/badge/JIRA/NDD-380/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-380) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
마이페이지 영상 삭제시 이미 삭제 요청이 된 영상에 대해서 중복해서 삭제 요청이 보내지게 되는 문제가 있어서 이를 수정했습니다.

# How
- 영상 삭제를 낙관적 업데이트로 구현해서 중복 삭제 요청을 막았습니다.
- 마이페이지 영상 전체 조회에 대한 쿼리를 suspense 쿼리로 변경해서 fallback으로 로딩을 처리했습니다.
- 기존 로직은 비디오 삭제 모달을 클릭했을 때 selectedVideoId state에 현재 비디오에 대한 id가 저장되고, 모달에서 confirm을 클릭시 해당하는 비디오가 삭제되도록 구성되어 있었습니다. 하지만 selectedVideoId state가 반영되기 전에 삭제 요청이 가는 경우 비디오가 정상적으로 삭제되지 않는다는 문제가 있어서 모달 코드를 각 아이템 내부에 넣어 해결했습니다.

# Result
비디오 삭제 문제 해결~

[NDD-380]: https://milk717.atlassian.net/browse/NDD-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ