### PR TITLE
[NDD-403] useMedia 리펙토링 및 오디오 비디오 디바이스 선택 기능 추가 (10h/3h)

### DIFF
--- a/src/atoms/media.ts
+++ b/src/atoms/media.ts
@@ -1,3 +1,4 @@
+import { getSupportedMimeTypes } from '@/utils/media';
 import { atom } from 'recoil';
 
 const mediaConnectStatus = [
@@ -20,5 +21,31 @@ export const connectStatusState = atom<ConnectStatus>({
 
 export const selectedMimeTypeState = atom<string>({
   key: 'selectedMimeTypeState',
-  default: '',
+  default: getSupportedMimeTypes()[0],
+});
+
+export const deviceListState = atom<{
+  video: MediaDeviceInfo[];
+  audioInput: MediaDeviceInfo[];
+  audioOutput: MediaDeviceInfo[];
+}>({
+  key: 'deviceListState',
+  default: {
+    video: [],
+    audioInput: [],
+    audioOutput: [],
+  },
+});
+
+export const selectedDeviceState = atom<{
+  video: string;
+  audioInput: string;
+  audioOutput: string;
+}>({
+  key: 'selectedDeviceState',
+  default: {
+    video: '',
+    audioInput: '',
+    audioOutput: '',
+  },
 });

--- a/src/components/foundation/StepPages/Step.tsx
+++ b/src/components/foundation/StepPages/Step.tsx
@@ -8,14 +8,15 @@ type StepProps<T> = {
 
 const Step = <T,>({ page, children, path }: StepProps<T>) => {
   return (
-    <div
-      css={css`
-        display: ${page === path ? 'block' : 'none'};
-        height: 100%;
-      `}
-    >
-      {children}
-    </div>
+    page === path && (
+      <div
+        css={css`
+          height: 100%;
+        `}
+      >
+        {children}
+      </div>
+    )
   );
 };
 

--- a/src/components/interviewSettingPage/VideoSettingPage/AudioSelectMenu.tsx
+++ b/src/components/interviewSettingPage/VideoSettingPage/AudioSelectMenu.tsx
@@ -1,0 +1,60 @@
+import { css } from '@emotion/react';
+import { Button, Menu, MenuItem } from '@foundation/index';
+import useMedia from '@hooks/useMedia';
+import { useState } from 'react';
+
+const AudioSelectMenu = () => {
+  const [micMenuOpen, setMicMenuOpen] = useState(false);
+  const {
+    deviceList,
+    startMedia,
+    stopMedia,
+    selectedDevice,
+    setSelectedDeviceIndex,
+  } = useMedia();
+
+  return (
+    <div
+      css={css`
+        position: relative;
+      `}
+    >
+      <Button onClick={() => setMicMenuOpen(true)}>
+        {selectedDevice.audioInput.label}
+      </Button>
+      <Menu
+        open={micMenuOpen}
+        closeMenu={() => setMicMenuOpen(false)}
+        css={css`
+          border: 1px solid #e0e0e0;
+        `}
+      >
+        {deviceList.audioInput.map((device, index) => (
+          <MenuItem
+            key={device.deviceId}
+            onClick={() => {
+              setSelectedDeviceIndex((pre) => ({
+                ...pre,
+                audioInput: index,
+              }));
+              stopMedia();
+              void startMedia({
+                audioDeviceId: device.deviceId,
+                videoDeviceId: selectedDevice.video.deviceId,
+              });
+            }}
+            css={css`
+              text-align: left;
+            `}
+          >
+            {device.deviceId === selectedDevice.audioInput.deviceId &&
+              '[선택됨] '}
+            {device.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </div>
+  );
+};
+
+export default AudioSelectMenu;

--- a/src/components/interviewSettingPage/VideoSettingPage/VideoSelectMenu.tsx
+++ b/src/components/interviewSettingPage/VideoSettingPage/VideoSelectMenu.tsx
@@ -1,0 +1,59 @@
+import { css } from '@emotion/react';
+import { Button, Menu, MenuItem } from '@foundation/index';
+import useMedia from '@hooks/useMedia';
+import { useState } from 'react';
+
+const VideoSelectMenu = () => {
+  const [videoMenuOpen, setVideoMenuOpen] = useState(false);
+  const {
+    deviceList,
+    startMedia,
+    stopMedia,
+    selectedDevice,
+    setSelectedDeviceIndex,
+  } = useMedia();
+
+  return (
+    <div
+      css={css`
+        position: relative;
+      `}
+    >
+      <Button onClick={() => setVideoMenuOpen(true)}>
+        {selectedDevice.video.label}
+      </Button>
+      <Menu
+        open={videoMenuOpen}
+        closeMenu={() => setVideoMenuOpen(false)}
+        css={css`
+          border: 1px solid #e0e0e0;
+        `}
+      >
+        {deviceList.video.map((device, index) => (
+          <MenuItem
+            key={device.deviceId}
+            onClick={() => {
+              setSelectedDeviceIndex((pre) => ({
+                ...pre,
+                video: index,
+              }));
+              stopMedia();
+              void startMedia({
+                audioDeviceId: selectedDevice.audioInput.deviceId,
+                videoDeviceId: device.deviceId,
+              });
+            }}
+            css={css`
+              text-align: left;
+            `}
+          >
+            {device.deviceId === selectedDevice.video.deviceId && '[선택됨] '}
+            {device.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </div>
+  );
+};
+
+export default VideoSelectMenu;

--- a/src/hooks/pages/Interview/useInterview.ts
+++ b/src/hooks/pages/Interview/useInterview.ts
@@ -22,15 +22,8 @@ const useInterview = () => {
   const { currentQuestion, getNextQuestion, isLastQuestion } =
     useInterviewFlow();
 
-  const {
-    media,
-    videoRef,
-    connectStatus,
-    selectedMimeType,
-    startMedia,
-    stopMedia,
-    connectVideo,
-  } = useMedia();
+  const { media, connectStatus, selectedMimeType, startMedia, selectedDevice } =
+    useMedia();
 
   const [isRecording, setIsRecording] = useState(false);
   const [isScriptInView, setIsScriptInView] = useState(true);
@@ -80,10 +73,6 @@ const useInterview = () => {
   ]);
 
   useEffect(() => {
-    if (isAllSuccess) connectVideo();
-  }, [media, stopMedia, isAllSuccess, connectVideo]);
-
-  useEffect(() => {
     if (isTimeOver) {
       handleStopRecording();
       setTimeOverModalIsOpen(true);
@@ -92,10 +81,10 @@ const useInterview = () => {
   }, [handleStopRecording, isTimeOver, setIsTimeOver]);
 
   return {
+    media,
     isAllSuccess,
     connectStatus,
     isRecording,
-    videoRef,
     isScriptInView,
     setIsScriptInView,
     recordedBlobs,
@@ -107,7 +96,11 @@ const useInterview = () => {
     handleDownload,
     timeOverModalIsOpen,
     setTimeOverModalIsOpen,
-    reloadMedia: () => void startMedia(),
+    reloadMedia: () =>
+      void startMedia({
+        audioDeviceId: selectedDevice.audioInput.deviceId,
+        videoDeviceId: selectedDevice.video.deviceId,
+      }),
   };
 };
 

--- a/src/page/interviewPage/index.tsx
+++ b/src/page/interviewPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { PATH } from '@constants/path';
 import { Navigate } from 'react-router-dom';
@@ -19,7 +19,7 @@ const InterviewPage: React.FC = () => {
     isAllSuccess,
     connectStatus,
     isRecording,
-    videoRef,
+    media,
     isScriptInView,
     setIsScriptInView,
     recordedBlobs,
@@ -37,6 +37,14 @@ const InterviewPage: React.FC = () => {
   const [interviewIntroModalIsOpen, setInterviewIntroModalIsOpen] =
     useState<boolean>(true);
 
+  const mirrorVideoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (mirrorVideoRef.current) {
+      mirrorVideoRef.current.srcObject = media;
+    }
+  }, [media]);
+
   if (!isAllSuccess || connectStatus === 'fail') {
     return <Navigate to={PATH.ROOT} />;
   } else
@@ -44,7 +52,7 @@ const InterviewPage: React.FC = () => {
       <InterviewPageLayout>
         <InterviewHeader isRecording={isRecording} />
         <InterviewMain
-          mirrorVideoRef={videoRef}
+          mirrorVideoRef={mirrorVideoRef}
           isScriptInView={isScriptInView}
           question={currentQuestion.questionContent}
           answer={currentQuestion.answerContent}

--- a/src/page/interviewSettingPage/index.tsx
+++ b/src/page/interviewSettingPage/index.tsx
@@ -55,7 +55,6 @@ const InterviewSettingPage: React.FC = () => {
       path: SETTING_PATH.CONNECTION,
       page: (
         <VideoSettingPage
-          isCurrentPage={currentPage === SETTING_PATH.CONNECTION}
           onPrevClick={() => {
             if (questionSettingState.from !== 'workbook')
               changeSearchParams(SETTING_PATH.QUESTION);

--- a/src/page/mediaStreamPage/index.tsx
+++ b/src/page/mediaStreamPage/index.tsx
@@ -1,17 +1,28 @@
 import { Outlet } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import useMedia from '@hooks/useMedia';
 import useInterviewSettings from '@hooks/atoms/useInterviewSettings';
 
 const MediaStreamPage = () => {
   const { resetAllSettings } = useInterviewSettings();
-  const { media, stopMedia } = useMedia();
+  const { stopMedia, connectStatus } = useMedia();
+  const preConnectStatus = useRef(connectStatus);
+  // 이전의 connectStatus 상태를 serving해주는 ref
+
+  preConnectStatus.current = connectStatus;
 
   useEffect(() => {
     return () => {
-      if (media) stopMedia();
+      if (preConnectStatus.current === 'fail') return;
+      // EDGE: 연결 도중 권한 문제로 끊어진다면 stopMedia를 실행해서 status를 pending상태로 만들지 않는다.
+      /**
+       * 부연 설명: clean up함수는 이전의 status를 가지고 있기 때문에 캠 및 오디오의 연결이 끊어졌다가 다시 연결되면 해당 로직이 실행됨
+       * 즉 브라우저의 권한으로 인해서 미디어가 끊어진다면 event가 감지가 되서 status가 fail이 된 후 해당 clean up이 실행됨 따라서 stopMedia가 실행이 되고 status가 pending상태가 됨
+       *
+       */
+      if (connectStatus === 'connect') stopMedia();
     };
-  }, [media, stopMedia]);
+  }, [connectStatus, stopMedia]);
 
   useEffect(() => {
     return () => {

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -4,22 +4,40 @@ export const closeMedia = (media: MediaStream | null) => {
   }
 };
 
-export const getMedia = async (): Promise<MediaStream | null> => {
+export const getDevices = async () => {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  const video = devices.filter((device) => device.kind === 'videoinput');
+  const audioInput = devices.filter((device) => device.kind === 'audioinput');
+
+  return { video, audioInput };
+};
+
+export const getMedia = async ({
+  selectedAudio,
+  selectedVideo,
+}: {
+  selectedAudio?: string;
+  selectedVideo?: string;
+}): Promise<MediaStream | null> => {
   try {
     const media = await navigator.mediaDevices.getUserMedia({
-      audio: {
-        echoCancellation: { exact: true },
-      },
-      video: {
-        width: 640,
-        height: 360,
-        frameRate: 30,
-      },
+      audio: selectedAudio
+        ? { deviceId: { exact: selectedAudio }, echoCancellation: true }
+        : { echoCancellation: true },
+      video: selectedVideo
+        ? {
+            deviceId: { exact: selectedVideo },
+            width: 640,
+            height: 360,
+            frameRate: 30,
+          }
+        : { width: 640, height: 360, frameRate: 30 },
     });
 
     return media;
   } catch (error) {
     throw new Error();
+    //TODO: custom error를 만들어야함
   }
 };
 


### PR DESCRIPTION
# Why

저번에 과제하면서 받은 피드백중 데이터 중심으로 설계하는 방법을 한번 적용해서 useMedia를 리펙토링 해보았습니다.
그래서 flow를 중심으로 상태 관리의 흐름을 재정의 하느라 시간이 조금 오래걸린것 같습니다.

# How

기존에 가지고 있었던 useMedia의 문제는 의도가 명확하지 않다는 점이 문제라 생각했습니다. 데이터를 어떻게 확장성 있고 flow를 처리할 것인지 중점으로 시작하였습니다.

그래서 해당 hook에 대한 정의 이외에 페이지에서 어떤 역할이 필요한지 먼저 정의하였습니다.


1. 



# Result

<!-- 해당 테스크를 통한 결과에 대해 담백하게 작성합니다.-->
<!-- ex) 작업한 내용, 스크린샷 -->

# Prize

<!-- 해당 테스크를 통해서 어떤 기술적 성취가 있었는지 작성합니다. (수치적인 개선점 등) -->

# Reference

<!-- 해당 테스크를 수행하며 참고한 Link를 모두 작성합니다. -->

# Link

<!-- jira 혹은 figma 링크를 작성합니다. (Jira ISSUE 번호) -->
