### PR TITLE
[NDD-411] 곰터뷰 서비스의 Service Tour 기능을 개발합니다 (13h/13h)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.11",
         "react-ga4": "^2.1.0",
+        "react-joyride": "^2.7.2",
         "react-router-dom": "^6.18.0",
         "recoil": "^0.7.7"
       },
@@ -1086,6 +1087,39 @@
         "node": ">=18.x"
       }
     },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
+      "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw=="
+    },
+    "node_modules/@gilbarbara/helpers": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/helpers/-/helpers-0.9.2.tgz",
+      "integrity": "sha512-vrydO6+8jOpzPaJ9Om2Ta6BStbpxBlg7j0uV27NnokG+k6bI95ys7rrw7P4hOcRYajkp+K/XpyLufFUUfYrKTQ==",
+      "dependencies": {
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^1.2.1"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "dependencies": {
+        "type-fest": "^4.1.0"
+      }
+    },
+    "node_modules/@gilbarbara/types/node_modules/type-fest": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.1.tgz",
+      "integrity": "sha512-7ZnJYTp6uc04uYRISWtiX3DSKB/fxNQT0B5o1OUeCqiQiwF+JC9+rJiZIDrPrNCLLuTqyQmh4VdQqh/ZOkv9MQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -1695,14 +1729,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/react": {
       "version": "18.2.47",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
       "integrity": "sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1721,8 +1753,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -2703,11 +2734,24 @@
         }
       }
     },
+    "node_modules/deep-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg=="
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -4527,6 +4571,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-lite": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-1.2.1.tgz",
+      "integrity": "sha512-pgF+L5bxC+10hLBgf6R2P4ZZUBOQIIacbdo8YvuCP8/JvsWxG7aZ9p10DYuLtifFci4l3VITphhMlMV4Y+urPw=="
+    },
     "node_modules/is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
@@ -5449,7 +5498,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5889,6 +5937,16 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.33",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
@@ -5957,7 +6015,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6046,15 +6103,93 @@
         "react": ">=16.13.1"
       }
     },
+    "node_modules/react-floater": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.7.9.tgz",
+      "integrity": "sha512-NXqyp9o8FAXOATOEo0ZpyaQ2KPb4cmPMXGWkx377QtJkIXHlHRAGer7ai0r0C1kG5gf+KJ6Gy+gdNIiosvSicg==",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "is-lite": "^0.8.2",
+        "popper.js": "^1.16.0",
+        "prop-types": "^15.8.1",
+        "tree-changes": "^0.9.1"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
+    },
+    "node_modules/react-floater/node_modules/@gilbarbara/deep-equal": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA=="
+    },
+    "node_modules/react-floater/node_modules/is-lite": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
+      "integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw=="
+    },
+    "node_modules/react-floater/node_modules/tree-changes": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.9.3.tgz",
+      "integrity": "sha512-vvvS+O6kEeGRzMglTKbc19ltLWNtmNt1cpBoSYLj/iEcPVvpJasemKOlxBrmZaCtDJoF+4bwv3m01UKYi8mukQ==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.1.1",
+        "is-lite": "^0.8.2"
+      }
+    },
     "node_modules/react-ga4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
       "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-joyride": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.7.2.tgz",
+      "integrity": "sha512-AVzEweJxjQMc6hXUbJlH6St987GCmw0pkCSoz+X3XBMQmrk57FCMOrh1LvyMvW5GaT95C4D5oZpoaVjaOsgptg==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
+        "@gilbarbara/helpers": "^0.9.0",
+        "deep-diff": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "is-lite": "^1.2.0",
+        "react-floater": "^0.7.9",
+        "react-innertext": "^1.1.5",
+        "react-is": "^16.13.1",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "tree-changes": "^0.11.2",
+        "type-fest": "^4.8.3"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
+    },
+    "node_modules/react-joyride/node_modules/type-fest": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.1.tgz",
+      "integrity": "sha512-7ZnJYTp6uc04uYRISWtiX3DSKB/fxNQT0B5o1OUeCqiQiwF+JC9+rJiZIDrPrNCLLuTqyQmh4VdQqh/ZOkv9MQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
@@ -6430,6 +6565,16 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg=="
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA=="
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -6857,6 +7002,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-changes": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.11.2.tgz",
+      "integrity": "sha512-4gXlUthrl+RabZw6lLvcCDl6KfJOCmrC16BC5CRdut1EAH509Omgg0BfKLY+ViRlzrvYOTWR0FMS2SQTwzumrw==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
+        "is-lite": "^1.2.0"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.11",
     "react-ga4": "^2.1.0",
+    "react-joyride": "^2.7.2",
     "react-router-dom": "^6.18.0",
     "recoil": "^0.7.7"
   },

--- a/src/atoms/interview.ts
+++ b/src/atoms/interview.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil';
+
+export const recordingState = atom<{
+  isRecording: boolean;
+}>({
+  key: 'recordingState',
+  default: {
+    isRecording: false,
+  },
+});

--- a/src/atoms/serviceTour.ts
+++ b/src/atoms/serviceTour.ts
@@ -1,0 +1,19 @@
+import { atom } from 'recoil';
+
+export const runState = atom<{
+  isRunning: boolean;
+}>({
+  key: 'runState',
+  default: {
+    isRunning: false,
+  },
+});
+
+export const stepIndexState = atom<{
+  stepIndex: number;
+}>({
+  key: 'stepIndexState',
+  default: {
+    stepIndex: 0,
+  },
+});

--- a/src/components/common/QuestionSelectionBox/QuestionAccordionList.tsx
+++ b/src/components/common/QuestionSelectionBox/QuestionAccordionList.tsx
@@ -47,6 +47,16 @@ const QuestionAccordionList: React.FC<QuestionAccordionListProps> = ({
     handleCancelEditMode();
   };
 
+  const getServiceStepID = (index: number, length: number) => {
+    return length < 7
+      ? index === length - 1
+        ? 'virtual-step-target-0'
+        : ''
+      : index === length - 4
+        ? 'virtual-step-target-0'
+        : '';
+  };
+
   return (
     <>
       <div
@@ -81,12 +91,19 @@ const QuestionAccordionList: React.FC<QuestionAccordionListProps> = ({
                 onInputChange={() => handleQuestionChecked(question.questionId)}
               />
             )}
-            <QuestionSelectionBoxAccordion
-              key={question.questionId}
-              question={question}
-              workbookId={workbookId}
-              isSelectable={!isEditMode}
-            />
+            <div
+              id={getServiceStepID(index, questionData.length)} // 현재 QuestionBox의 UI 수정이 이루어 지지 않았습니다. 매우 특수한 경우로 예외처리 합니다
+              css={css`
+                width: 100%;
+              `}
+            >
+              <QuestionSelectionBoxAccordion
+                key={question.questionId}
+                question={question}
+                workbookId={workbookId}
+                isSelectable={!isEditMode}
+              />
+            </div>
           </div>
         ))}
         {isEditMode && (

--- a/src/components/common/ServiceTourStep/ServiceTourStep.tsx
+++ b/src/components/common/ServiceTourStep/ServiceTourStep.tsx
@@ -1,0 +1,15 @@
+interface TourStepWrapperProps {
+  children: React.ReactElement;
+  stepIndex: number;
+}
+
+const ServiceTourStep: React.FC<TourStepWrapperProps> = ({
+  children,
+  stepIndex,
+}) => {
+  const virtualDivId = `virtual-step-target-${stepIndex}`;
+
+  return <div id={virtualDivId}>{children}</div>;
+};
+
+export default ServiceTourStep;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -10,3 +10,4 @@ export { default as ResponsiveMenu } from './ResponsiveMenu/ResponsiveMenu';
 export { default as Mirror } from './Mirror/Mirror';
 export { default as WorkbookGeneratorModal } from '@common/QuestionSelectionBox/WorkbookGeneratorModal/WorkbookGeneratorModal';
 export { default as ShareRangeToggle } from './ShareRangeToggle/ShareRangeToggle';
+export { default as ServiceTourStep } from './ServiceTourStep/ServiceTourStep';

--- a/src/components/interviewPage/InterviewFooter/InterviewFooter.tsx
+++ b/src/components/interviewPage/InterviewFooter/InterviewFooter.tsx
@@ -13,6 +13,7 @@ import {
   InterviewExitModal,
   InterviewFinishModal,
 } from '../InterviewModal/index';
+import { ServiceTourStep } from '@common/index';
 type InterviewFooterProps = {
   isRecording: boolean;
   recordedBlobs: Blob[];
@@ -64,11 +65,13 @@ const InterviewFooter: React.FC<InterviewFooterProps> = ({
         handleStartRecording={handleStartRecording}
         handleStopRecording={handleStopRecording}
       />
-
-      {!isRecording && recordedBlobs.length === 0 && (
-        <NextButton handleNext={handleNext} />
-      )}
-
+      <ServiceTourStep stepIndex={5}>
+        {!isRecording && recordedBlobs.length === 0 ? (
+          <NextButton handleNext={handleNext} />
+        ) : (
+          <div></div>
+        )}
+      </ServiceTourStep>
       <InterviewExitModal
         isOpen={interviewExitModalIsOpen}
         closeModal={() => setInterviewExitModalIsOpen((prev) => !prev)}

--- a/src/components/interviewPage/InterviewFooter/RecordControlButton.tsx
+++ b/src/components/interviewPage/InterviewFooter/RecordControlButton.tsx
@@ -5,6 +5,7 @@ import { Icon, Typography } from '@foundation/index';
 
 import RecordStartModal from '../InterviewModal/RecordStartModal';
 import { useEffect, useState } from 'react';
+import { ServiceTourStep } from '@common/index';
 
 type RecordControlButtonProps = {
   isRecording: boolean;
@@ -49,30 +50,32 @@ const RecordControlButton: React.FC<RecordControlButtonProps> = ({
         title={`녹화를 ${isRecording ? '종료' : '시작'}합니다`}
         position="top"
       >
-        <div
-          css={css`
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            cursor: pointer;
-            gap: 0.75rem;
-          `}
-          onClick={
-            isRecording
-              ? handleStopRecording
-              : () => setRecordStartModalIsOpen(true)
-          }
-        >
-          {isRecording ? (
-            <Icon id="record-stop" width="2rem" height="2rem" />
-          ) : (
-            <Icon id="record-start" width="2rem" height="2rem" />
-          )}
-          <Typography variant={'body1'} color={theme.colors.text.white}>
-            {isRecording ? '녹화종료' : '녹화시작'}
-          </Typography>
-        </div>
+        <ServiceTourStep stepIndex={4}>
+          <div
+            css={css`
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              justify-content: center;
+              cursor: pointer;
+              gap: 0.75rem;
+            `}
+            onClick={
+              isRecording
+                ? handleStopRecording
+                : () => setRecordStartModalIsOpen(true)
+            }
+          >
+            {isRecording ? (
+              <Icon id="record-stop" width="2rem" height="2rem" />
+            ) : (
+              <Icon id="record-start" width="2rem" height="2rem" />
+            )}
+            <Typography variant={'body1'} color={theme.colors.text.white}>
+              {isRecording ? '녹화종료' : '녹화시작'}
+            </Typography>
+          </div>
+        </ServiceTourStep>
       </Tooltip>
 
       <RecordStartModal

--- a/src/components/interviewPage/InterviewHeader/RecordStatus.tsx
+++ b/src/components/interviewPage/InterviewHeader/RecordStatus.tsx
@@ -1,27 +1,31 @@
 import { theme } from '@styles/theme';
 import { Typography, LeadingDot } from '@foundation/index';
+import { ServiceTourStep } from '@common/index';
+
 type RecordStatusType = {
   isRecording: boolean;
 };
 
 const RecordStatus: React.FC<RecordStatusType> = ({ isRecording }) => {
   return (
-    <LeadingDot
-      color={
-        isRecording
-          ? `${theme.colors.status.record}`
-          : `${theme.colors.status.active}`
-      }
-    >
-      <Typography
-        noWrap
-        paragraph
-        variant={'body1'}
-        color={theme.colors.text.white}
+    <ServiceTourStep stepIndex={2}>
+      <LeadingDot
+        color={
+          isRecording
+            ? `${theme.colors.status.record}`
+            : `${theme.colors.status.active}`
+        }
       >
-        {isRecording ? '녹화중' : '녹화준비'}
-      </Typography>
-    </LeadingDot>
+        <Typography
+          noWrap
+          paragraph
+          variant={'body1'}
+          color={theme.colors.text.white}
+        >
+          {isRecording ? '녹화중' : '녹화준비'}
+        </Typography>
+      </LeadingDot>
+    </ServiceTourStep>
   );
 };
 export default RecordStatus;

--- a/src/components/interviewPage/InterviewHeader/RecordTimer.tsx
+++ b/src/components/interviewPage/InterviewHeader/RecordTimer.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 
 import { theme } from '@styles/theme';
 import { Icon, Typography } from '@foundation/index';
+import { ServiceTourStep } from '@common/index';
 
 interface RecordTimerProps {
   isRecording: boolean;
@@ -30,23 +31,25 @@ const RecordTimer: React.FC<RecordTimerProps> = ({ isRecording }) => {
   }, [isRecording]);
 
   return (
-    <div
-      css={css`
-        display: flex;
-        gap: 0.375rem;
-        align-items: center;
-      `}
-    >
-      <Icon id="timer" width="1.5rem" height="1.5rem" />
-      <Typography
-        noWrap
-        paragraph
-        variant={'body1'}
-        color={theme.colors.text.white}
+    <ServiceTourStep stepIndex={3}>
+      <div
+        css={css`
+          display: flex;
+          gap: 0.375rem;
+          align-items: center;
+        `}
       >
-        {formatTime(curTime)}
-      </Typography>
-    </div>
+        <Icon id="timer" width="1.5rem" height="1.5rem" />
+        <Typography
+          noWrap
+          paragraph
+          variant={'body1'}
+          color={theme.colors.text.white}
+        >
+          {formatTime(curTime)}
+        </Typography>
+      </div>
+    </ServiceTourStep>
   );
 };
 

--- a/src/components/interviewPage/InterviewMain/InterviewQuestion.tsx
+++ b/src/components/interviewPage/InterviewMain/InterviewQuestion.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@foundation/index';
 import { css } from '@emotion/react';
 import { theme } from '@styles/theme';
 import { useEffect, useState } from 'react';
+import { ServiceTourStep } from '@common/index';
 type InterviewQuestionProps = {
   question: string;
 };
@@ -47,17 +48,19 @@ const InterviewQuestion: React.FC<InterviewQuestionProps> = ({ question }) => {
         }
       `}
     >
-      <Typography
-        noWrap
-        paragraph
-        variant={highlight ? 'title3' : 'title4'}
-        color={theme.colors.text.white}
-        css={css`
-          transition: all 0.3s ease-in-out;
-        `}
-      >
-        {question}
-      </Typography>
+      <ServiceTourStep stepIndex={1}>
+        <Typography
+          noWrap
+          paragraph
+          variant={highlight ? 'title3' : 'title4'}
+          color={theme.colors.text.white}
+          css={css`
+            transition: all 0.3s ease-in-out;
+          `}
+        >
+          {question}
+        </Typography>
+      </ServiceTourStep>
     </div>
   );
 };

--- a/src/components/interviewPage/InterviewServiceTour.tsx
+++ b/src/components/interviewPage/InterviewServiceTour.tsx
@@ -1,0 +1,185 @@
+import { PropsWithChildren, useEffect } from 'react';
+import Joyride, { CallBackProps, Step } from 'react-joyride';
+import { runState, stepIndexState } from '@atoms/serviceTour';
+import { useRecoilState } from 'recoil';
+import { theme } from '@styles/theme';
+import { recordingState } from '@atoms/interview';
+
+const InterviewPageServiceTour: React.FC<PropsWithChildren> = () => {
+  const [{ isRunning: isRunning }, setIsRunning] = useRecoilState(runState);
+  const [{ stepIndex: stepIndex }, setStepIndex] =
+    useRecoilState(stepIndexState);
+
+  const [{ isRecording: isRecording }] = useRecoilState(recordingState);
+  useEffect(() => {
+    setStepIndex({ stepIndex: 0 });
+  }, [setStepIndex]);
+
+  useEffect(() => {
+    if (stepIndex === 4 && isRecording) {
+      setStepIndex({ stepIndex: 5 });
+    } else if (!isRecording && stepIndex === 6) {
+      setStepIndex({ stepIndex: 7 });
+    }
+  }, [isRecording, setStepIndex, stepIndex]);
+
+  const handleJoyrideCallback = (data: CallBackProps) => {
+    const { action, index, type } = data;
+    if (action === 'next' && index === 0 && type === 'step:after') {
+      setStepIndex({ stepIndex: 1 });
+    } else if (action === 'next' && index === 1 && type === 'step:after') {
+      setStepIndex({ stepIndex: 2 });
+    } else if (action === 'next' && index === 2 && type === 'step:after') {
+      setStepIndex({ stepIndex: 3 });
+    } else if (action === 'next' && index === 3 && type === 'step:after') {
+      setStepIndex({ stepIndex: 4 });
+    } else if (action === 'next' && index === 5 && type === 'step:after') {
+      setStepIndex({ stepIndex: 6 });
+    } else if (action === 'skip') {
+      setIsRunning({ isRunning: false });
+      localStorage.setItem('skipped', new Date().toISOString());
+    }
+  };
+
+  const steps: Step[] = [
+    {
+      content: (
+        <>
+          <h1>곰터뷰 모의 면접 안내</h1>
+          면접화면에서의 기능설명을 시작해 볼게요!🤗
+        </>
+      ),
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      placement: 'center',
+      disableOverlayClose: true,
+
+      target: 'body',
+    },
+    {
+      content: <h2>면접 질문입니다! 잘 고민해서 대답해 주세요!</h2>,
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      disableBeacon: true,
+      disableOverlayClose: true,
+      hideBackButton: true,
+      placement: 'bottom',
+      spotlightClicks: true,
+      showSkipButton: false,
+      styles: {
+        options: {
+          zIndex: 10000,
+        },
+      },
+      target: '#virtual-step-target-1',
+    },
+    {
+      content: (
+        <h2>
+          녹화 상태를 확인합니다!! <br /> 현재는 녹화준비 상태입니다
+        </h2>
+      ),
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      disableBeacon: true,
+      disableOverlayClose: true,
+      hideBackButton: true,
+      placement: 'bottom',
+      showSkipButton: false,
+      spotlightClicks: true,
+      target: '#virtual-step-target-2',
+    },
+    {
+      content: (
+        <h2>
+          현재 녹화 진행 시간을 안내합니다.
+          <br /> 3분이상 소요되면 녹화는 종료됩니다!
+        </h2>
+      ),
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      disableBeacon: true,
+      disableOverlayClose: true,
+      hideBackButton: true,
+      placement: 'bottom',
+      showSkipButton: false,
+      spotlightClicks: true,
+      target: '#virtual-step-target-3',
+    },
+    {
+      content: (
+        <h2>
+          녹화를 시작하는 버튼입니다!
+          <br /> 클릭해주세요! 혹은 space를 눌러주세요!
+        </h2>
+      ),
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      disableBeacon: true,
+      disableOverlayClose: true,
+      placement: 'top',
+      spotlightClicks: true,
+      hideFooter: true,
+      target: '#virtual-step-target-4',
+    },
+    {
+      content: (
+        <h2>
+          녹화 상태를 확인합니다!! <br /> 현재는 녹화 중 입니다
+        </h2>
+      ),
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      disableBeacon: true,
+      disableOverlayClose: true,
+      hideBackButton: true,
+      showSkipButton: false,
+      placement: 'bottom',
+      target: '#virtual-step-target-2',
+    },
+    {
+      content: (
+        <h2>
+          녹화를 종료하는 버튼입니다!
+          <br /> 클릭해주세요! 혹은 space를 눌러주세요!
+        </h2>
+      ),
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      disableBeacon: true,
+      disableOverlayClose: true,
+      placement: 'top',
+      spotlightClicks: true,
+      hideFooter: true,
+      target: '#virtual-step-target-4',
+    },
+    {
+      content: (
+        <h2>
+          면접이 모두 종료되었습니다🤗
+          <br /> 튜토리얼을 함께 해주셔서 정말 감사합니다!
+        </h2>
+      ),
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      disableBeacon: false,
+      disableOverlayClose: true,
+      placement: 'top',
+      spotlightClicks: true,
+      hideFooter: true,
+      target: '#virtual-step-target-5',
+    },
+  ];
+
+  return (
+    <Joyride
+      callback={handleJoyrideCallback}
+      stepIndex={stepIndex}
+      continuous
+      hideCloseButton
+      showSkipButton
+      run={isRunning}
+      steps={steps}
+      styles={{
+        buttonNext: {
+          backgroundColor: `${theme.colors.point.primary.default}`,
+          color: 'white',
+        },
+      }}
+    />
+  );
+};
+
+export default InterviewPageServiceTour;

--- a/src/components/interviewPage/index.ts
+++ b/src/components/interviewPage/index.ts
@@ -2,3 +2,4 @@ export { default as InterviewFooter } from './InterviewFooter/InterviewFooter';
 export { default as InterviewHeader } from './InterviewHeader/InterviewHeader';
 export { default as InterviewMain } from './InterviewMain/InterviewMain';
 export { default as InterviewPageLayout } from './InterviewPageLayout';
+export { default as InterviewPageServiceTour } from './InterviewServiceTour';

--- a/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
+++ b/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@foundation/index';
 import { css } from '@emotion/react';
 import { InterviewSettingFooter } from '@components/interviewSettingPage/interviewSettingFooter';
+import { ServiceTourStep } from '@common/index';
 
 type InterviewSettingContentLayoutProps = {
   onPrevClick?: () => void;
@@ -50,16 +51,18 @@ const InterviewSettingContentLayout: React.FC<
           >
             이전
           </Button>
-          <Button
-            onClick={onNextClick}
-            size="lg"
-            css={css`
-              padding: 0.6rem 2rem;
-            `}
-            disabled={disabledNext}
-          >
-            다음
-          </Button>
+          <ServiceTourStep stepIndex={99}>
+            <Button
+              onClick={onNextClick}
+              size="lg"
+              css={css`
+                padding: 0.6rem 2rem;
+              `}
+              disabled={disabledNext}
+            >
+              다음
+            </Button>
+          </ServiceTourStep>
         </div>
       </InterviewSettingFooter>
     </div>

--- a/src/components/interviewSettingPage/ServiceTour/QuestionSelectPageServiceTour.tsx
+++ b/src/components/interviewSettingPage/ServiceTour/QuestionSelectPageServiceTour.tsx
@@ -1,0 +1,100 @@
+import { PropsWithChildren, useEffect } from 'react';
+import Joyride, { CallBackProps, Step } from 'react-joyride';
+import { runState, stepIndexState } from '@atoms/serviceTour';
+import { useRecoilState } from 'recoil';
+import { useLocation, useSearchParams } from 'react-router-dom';
+import { questionSetting } from '@atoms/interviewSetting';
+import { PATH, SETTING_PATH } from '@constants/path';
+import { theme } from '@styles/theme';
+
+const QuestionSelectPageServiceTour: React.FC<PropsWithChildren> = () => {
+  const [{ isRunning: isRunning }, setInRunning] = useRecoilState(runState);
+  const [{ stepIndex: stepIndex }, setStepIndex] =
+    useRecoilState(stepIndexState);
+  const { pathname: curPath } = useLocation();
+  const [{ isSuccess }] = useRecoilState(questionSetting);
+  const [searchParams] = useSearchParams();
+  const currentPage = searchParams.get('page');
+
+  const handleJoyrideCallback = (data: CallBackProps) => {
+    const { action, index } = data;
+    if (index === 0 && action === 'next') {
+      setStepIndex({ stepIndex: 1 });
+    } else if (action === 'skip') {
+      setInRunning({ isRunning: false });
+      localStorage.setItem('skipped', new Date().toISOString());
+    }
+  };
+
+  useEffect(() => {
+    if (
+      isRunning &&
+      curPath === PATH.INTERVIEW_SETTING &&
+      currentPage === SETTING_PATH.QUESTION
+    ) {
+      setStepIndex({ stepIndex: 0 });
+    }
+  }, [setInRunning, curPath, setStepIndex, isRunning, currentPage]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      setStepIndex({ stepIndex: 2 });
+    }
+  }, [isSuccess, setStepIndex]);
+
+  const steps: Step[] = [
+    {
+      content: (
+        <h2>
+          면접 문제를 선택하는 페이지 입니다😊
+          <br />
+          로그인 하시면 다양한 문제를 직접 만들거나 다른 사람의 좋은 문제를
+          가져올 수도 있어요!
+        </h2>
+      ),
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      placement: 'center',
+      disableOverlayClose: true,
+      target: 'body',
+    },
+    {
+      content: <h2>면접 문제를 선택해 주세요!</h2>,
+      disableBeacon: true,
+      disableOverlayClose: true,
+      placement: 'bottom',
+      hideFooter: true,
+      spotlightClicks: true,
+      target: '#virtual-step-target-0',
+    },
+    {
+      content: <h2>카메라 및 마이크 연결 페이지로 이동하기</h2>,
+      disableBeacon: true,
+      disableOverlayClose: true,
+      hideFooter: true,
+      placement: 'top',
+      spotlightClicks: true,
+      target: '#virtual-step-target-99',
+    },
+  ];
+
+  return (
+    <Joyride
+      callback={handleJoyrideCallback}
+      continuous
+      hideCloseButton
+      stepIndex={stepIndex}
+      run={isRunning}
+      showProgress
+      showSkipButton
+      steps={steps}
+      styles={{
+        buttonNext: {
+          backgroundColor: `${theme.colors.point.primary.default}`,
+          color: 'white',
+        },
+      }}
+    />
+  );
+};
+
+export default QuestionSelectPageServiceTour;

--- a/src/components/interviewSettingPage/ServiceTour/RecordPageServiceTour.tsx
+++ b/src/components/interviewSettingPage/ServiceTour/RecordPageServiceTour.tsx
@@ -1,0 +1,82 @@
+import { PropsWithChildren, useEffect } from 'react';
+import Joyride, { Step } from 'react-joyride';
+import { runState, stepIndexState } from '@atoms/serviceTour';
+import { useRecoilState } from 'recoil';
+import { useLocation, useSearchParams } from 'react-router-dom';
+import { recordSetting } from '@atoms/interviewSetting';
+import { PATH, SETTING_PATH } from '@constants/path';
+
+const RecordPageServiceTour: React.FC<PropsWithChildren> = () => {
+  const [{ isRunning: isRunning }, setInRunning] = useRecoilState(runState);
+  const [{ stepIndex: stepIndex }, setStepIndex] =
+    useRecoilState(stepIndexState);
+  const { pathname: curPath } = useLocation();
+  const [{ isSuccess }] = useRecoilState(recordSetting);
+  const [searchParams] = useSearchParams();
+  const currentPage = searchParams.get('page');
+  useEffect(() => {
+    if (
+      isRunning &&
+      curPath === PATH.INTERVIEW_SETTING &&
+      currentPage === SETTING_PATH.RECORD
+    ) {
+      setStepIndex({ stepIndex: 0 });
+    }
+  }, [setInRunning, curPath, setStepIndex, isRunning, currentPage]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      setStepIndex({ stepIndex: 1 });
+    }
+  }, [isSuccess, setStepIndex]);
+
+  const steps: Step[] = [
+    {
+      content: (
+        <>
+          <h1>로컬 저장 선택😚</h1>
+          <div>별도의 서버가 아닌 컴퓨터에 면접영상을 저장합니다.</div>
+          <div>하지만 로그인 하면 마이페이지에서 확인이 가능하다고...?!!</div>
+        </>
+      ),
+      hideFooter: true,
+      disableOverlayClose: true,
+      placement: 'right',
+      spotlightClicks: true,
+      target: '#virtual-step-target-0',
+    },
+    {
+      content: (
+        <h2>
+          설정하시느라 고생하셨어요😊
+          <br /> 이제 면접을 시작해볼까요?!
+        </h2>
+      ),
+      disableOverlayClose: true,
+      hideFooter: true,
+      placement: 'top',
+      spotlightClicks: true,
+      target: '#virtual-step-target-99',
+    },
+  ];
+
+  return (
+    <Joyride
+      continuous
+      hideCloseButton
+      stepIndex={stepIndex}
+      run={isRunning}
+      showProgress
+      showSkipButton
+      hideBackButton
+      steps={steps}
+      styles={{
+        options: {
+          zIndex: 10000,
+        },
+      }}
+    />
+  );
+};
+
+export default RecordPageServiceTour;

--- a/src/components/interviewSettingPage/ServiceTour/TermPageServiceTour.tsx
+++ b/src/components/interviewSettingPage/ServiceTour/TermPageServiceTour.tsx
@@ -1,0 +1,80 @@
+import { PropsWithChildren, useEffect } from 'react';
+import Joyride, { Step } from 'react-joyride';
+import { runState, stepIndexState } from '@atoms/serviceTour';
+import { useRecoilState } from 'recoil';
+import { useLocation, useSearchParams } from 'react-router-dom';
+import { serviceTerms } from '@atoms/interviewSetting';
+import { PATH, SETTING_PATH } from '@constants/path';
+
+const TermPageServiceTour: React.FC<PropsWithChildren> = () => {
+  const [{ isRunning: isRunning }, setInRunning] = useRecoilState(runState);
+  const [{ stepIndex: stepIndex }, setStepIndex] =
+    useRecoilState(stepIndexState);
+  const { pathname: curPath } = useLocation();
+  const [{ isSuccess }] = useRecoilState(serviceTerms);
+  const [searchParams] = useSearchParams();
+  const currentPage = searchParams.get('page');
+
+  useEffect(() => {
+    if (
+      isRunning &&
+      curPath === PATH.INTERVIEW_SETTING &&
+      currentPage === SETTING_PATH.TERMS
+    ) {
+      setStepIndex({ stepIndex: 0 });
+    }
+  }, [setInRunning, curPath, setStepIndex, isRunning, currentPage]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      setStepIndex({ stepIndex: 1 });
+    }
+  }, [isSuccess, setStepIndex]);
+
+  const steps: Step[] = [
+    {
+      content: (
+        <>
+          <h1>서비스 이용안내</h1>
+          곰터뷰 서비스를 사용하시며 저장된 영상들은 유저의 별도 설정으로
+          인해서만 공개됩니다!
+        </>
+      ),
+      disableBeacon: true,
+      hideFooter: true,
+      disableOverlayClose: true,
+      placement: 'bottom',
+      spotlightClicks: true,
+      target: '#virtual-step-target-0',
+    },
+    {
+      content: <h2>문제 설정 페이지로 이동하기</h2>,
+      disableBeacon: true,
+      disableOverlayClose: true,
+      hideFooter: true,
+      placement: 'top',
+      spotlightClicks: true,
+      target: '#virtual-step-target-99',
+    },
+  ];
+
+  return (
+    <Joyride
+      continuous
+      hideCloseButton
+      stepIndex={stepIndex}
+      run={isRunning}
+      showProgress
+      showSkipButton
+      hideBackButton
+      steps={steps}
+      styles={{
+        options: {
+          zIndex: 10000,
+        },
+      }}
+    />
+  );
+};
+
+export default TermPageServiceTour;

--- a/src/components/interviewSettingPage/ServiceTour/VideoSettingPageServiceTour.tsx
+++ b/src/components/interviewSettingPage/ServiceTour/VideoSettingPageServiceTour.tsx
@@ -1,0 +1,108 @@
+import { PropsWithChildren, useEffect } from 'react';
+import Joyride, { CallBackProps, Step } from 'react-joyride';
+import { runState, stepIndexState } from '@atoms/serviceTour';
+import { useRecoilState } from 'recoil';
+import { useLocation, useSearchParams } from 'react-router-dom';
+import { videoSetting } from '@atoms/interviewSetting';
+import { PATH, SETTING_PATH } from '@constants/path';
+import { theme } from '@styles/theme';
+
+const VideoSettingPageServiceTour: React.FC<PropsWithChildren> = () => {
+  const [{ isRunning: isRunning }, setIsRunning] = useRecoilState(runState);
+  const [{ stepIndex: stepIndex }, setStepIndex] =
+    useRecoilState(stepIndexState);
+  const { pathname: curPath } = useLocation();
+  const [{ isSuccess }] = useRecoilState(videoSetting);
+  const [searchParams] = useSearchParams();
+  const currentPage = searchParams.get('page');
+
+  const handleJoyrideCallback = (data: CallBackProps) => {
+    const { action, index } = data;
+    if (index === 0 && action === 'next') {
+      setStepIndex({ stepIndex: 1 });
+    } else if (index === 1 && action === 'next' && isSuccess) {
+      setStepIndex({ stepIndex: 2 });
+    } else if (action === 'skip') {
+      setIsRunning({ isRunning: false });
+      localStorage.setItem('skipped', new Date().toISOString());
+    }
+  };
+
+  useEffect(() => {
+    if (
+      isRunning &&
+      curPath === PATH.INTERVIEW_SETTING &&
+      currentPage === SETTING_PATH.CONNECTION
+    ) {
+      setStepIndex({ stepIndex: 0 });
+    }
+  }, [curPath, setStepIndex, isRunning, currentPage, setIsRunning]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      setStepIndex({ stepIndex: 2 });
+    } else {
+      setStepIndex({ stepIndex: 1 });
+    }
+  }, [isSuccess, setStepIndex]);
+
+  const steps: Step[] = [
+    {
+      content: <h2>면접에 필요한 카메라와 마이크를 설정합니다😊</h2>,
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      placement: 'center',
+      disableOverlayClose: true,
+      target: 'body',
+    },
+    {
+      content: (
+        <h2>
+          카메라 연결이 되지 않았다면, 브라우저 설정에서 카메라 및 마이크 연결을
+          확인해주세요😚
+        </h2>
+      ),
+      disableBeacon: true,
+      disableOverlayClose: true,
+      placement: 'right',
+      spotlightClicks: true,
+      hideFooter: isSuccess ? false : true,
+      hideBackButton: true,
+      spotlightPadding: 100,
+      target: '#virtual-step-target-1',
+    },
+    {
+      content: (
+        <h2>
+          카메라 연결도 완료하셨군요🎉 <br />곧 면접을 시작하실 수 있어요😊
+        </h2>
+      ),
+      disableBeacon: true,
+      disableOverlayClose: true,
+      hideFooter: true,
+      placement: 'top',
+      spotlightClicks: true,
+      target: '#virtual-step-target-99',
+    },
+  ];
+
+  return (
+    <Joyride
+      callback={handleJoyrideCallback}
+      continuous
+      hideCloseButton
+      stepIndex={stepIndex}
+      run={isRunning}
+      showProgress
+      showSkipButton
+      steps={steps}
+      styles={{
+        buttonNext: {
+          backgroundColor: `${theme.colors.point.primary.default}`,
+          color: 'white',
+        },
+      }}
+    />
+  );
+};
+
+export default VideoSettingPageServiceTour;

--- a/src/components/interviewSettingPage/index.ts
+++ b/src/components/interviewSettingPage/index.ts
@@ -3,3 +3,4 @@ export { default as InterviewSettingPageLayout } from '@components/interviewSett
 export { default as RecordRadio } from '@components/interviewSettingPage/RecordPage/RecordRadio';
 export { InterviewSettingFooter } from '@components/interviewSettingPage/interviewSettingFooter';
 export { default as TermPageServiceTour } from './ServiceTour/TermPageServiceTour';
+export { default as QuestionSelectPageServiceTour } from './ServiceTour/QuestionSelectPageServiceTour';

--- a/src/components/interviewSettingPage/index.ts
+++ b/src/components/interviewSettingPage/index.ts
@@ -4,4 +4,5 @@ export { default as RecordRadio } from '@components/interviewSettingPage/RecordP
 export { InterviewSettingFooter } from '@components/interviewSettingPage/interviewSettingFooter';
 export { default as TermPageServiceTour } from './ServiceTour/TermPageServiceTour';
 export { default as QuestionSelectPageServiceTour } from './ServiceTour/QuestionSelectPageServiceTour';
+export { default as RecordPageServiceTour } from './ServiceTour/RecordPageServiceTour';
 export { default as VideoSettingPageServiceTour } from './ServiceTour/VideoSettingPageServiceTour';

--- a/src/components/interviewSettingPage/index.ts
+++ b/src/components/interviewSettingPage/index.ts
@@ -2,3 +2,4 @@ export { default as Description } from '@components/interviewSettingPage/Descrip
 export { default as InterviewSettingPageLayout } from '@components/interviewSettingPage/InterviewSettingPageLayout';
 export { default as RecordRadio } from '@components/interviewSettingPage/RecordPage/RecordRadio';
 export { InterviewSettingFooter } from '@components/interviewSettingPage/interviewSettingFooter';
+export { default as TermPageServiceTour } from './ServiceTour/TermPageServiceTour';

--- a/src/components/interviewSettingPage/index.ts
+++ b/src/components/interviewSettingPage/index.ts
@@ -4,3 +4,4 @@ export { default as RecordRadio } from '@components/interviewSettingPage/RecordP
 export { InterviewSettingFooter } from '@components/interviewSettingPage/interviewSettingFooter';
 export { default as TermPageServiceTour } from './ServiceTour/TermPageServiceTour';
 export { default as QuestionSelectPageServiceTour } from './ServiceTour/QuestionSelectPageServiceTour';
+export { default as VideoSettingPageServiceTour } from './ServiceTour/VideoSettingPageServiceTour';

--- a/src/components/landingPage/LadingPageServiceTour.tsx
+++ b/src/components/landingPage/LadingPageServiceTour.tsx
@@ -1,0 +1,92 @@
+import { PropsWithChildren, useEffect, useState } from 'react';
+import Joyride, { CallBackProps, Step } from 'react-joyride';
+import { runState } from '@atoms/serviceTour';
+import { useRecoilState } from 'recoil';
+import { useLocation } from 'react-router-dom';
+import { theme } from '@styles/theme';
+import { PATH } from '@constants/path';
+
+const LandingPageServiceTour: React.FC<PropsWithChildren> = () => {
+  const [{ isRunning: isRunning }, setInRunning] = useRecoilState(runState);
+  const [stepIndex, setStepIndex] = useState(0);
+  const { pathname: curPath } = useLocation();
+
+  useEffect(() => {
+    if (curPath === PATH.ROOT && checkIsSkipped()) {
+      setInRunning({ isRunning: true });
+      setStepIndex(0);
+    }
+  }, [setInRunning, curPath, setStepIndex]);
+
+  const checkIsSkipped = () => {
+    const skippedDate = localStorage.getItem('skipped');
+    if (skippedDate) {
+      const now = new Date();
+      const skippedTime = new Date(skippedDate).getTime();
+      const diff = now.getTime() - skippedTime;
+      return diff > 24 * 60 * 10 * 1000;
+    }
+    return true;
+  };
+
+  const handleJoyrideCallback = (data: CallBackProps) => {
+    const { action, index } = data;
+    if (index === 0 && action === 'next') {
+      setStepIndex(1);
+    } else if (action === 'skip') {
+      setInRunning({ isRunning: false });
+      localStorage.setItem('skipped', new Date().toISOString());
+    }
+  };
+
+  const steps: Step[] = [
+    {
+      content: (
+        <>
+          <h1>곰터뷰 튜토리얼 안내🤗</h1>
+          곰터뷰가 익숙하지 않으신 분들을 위해 준비한 <br /> 튜토리얼입니다!
+          함께 떠나볼까요~!
+        </>
+      ),
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      placement: 'center',
+      disableOverlayClose: true,
+      target: 'body',
+    },
+    {
+      content: <h2>곰터뷰는 로그인하지 않고도 이용하실수 있어요😎</h2>,
+      locale: { skip: <strong aria-label="skip">S-K-I-P</strong> },
+      disableBeacon: true,
+      disableOverlayClose: true,
+      hideFooter: true,
+      placement: 'right',
+      spotlightClicks: true,
+      styles: {
+        options: {
+          zIndex: 10000,
+        },
+      },
+      target: '#virtual-step-target-1',
+    },
+  ];
+
+  return (
+    <Joyride
+      callback={handleJoyrideCallback}
+      continuous
+      hideCloseButton
+      stepIndex={stepIndex}
+      run={isRunning}
+      showSkipButton
+      steps={steps}
+      styles={{
+        buttonNext: {
+          backgroundColor: `${theme.colors.point.primary.default}`,
+          color: 'white',
+        },
+      }}
+    />
+  );
+};
+
+export default LandingPageServiceTour;

--- a/src/components/landingPage/LadingPageServiceTour.tsx
+++ b/src/components/landingPage/LadingPageServiceTour.tsx
@@ -5,6 +5,7 @@ import { useRecoilState } from 'recoil';
 import { useLocation } from 'react-router-dom';
 import { theme } from '@styles/theme';
 import { PATH } from '@constants/path';
+import ServiceTourNoticeDialog from './ServiceTourNoticeDialog';
 
 const LandingPageServiceTour: React.FC<PropsWithChildren> = () => {
   const [{ isRunning: isRunning }, setInRunning] = useRecoilState(runState);
@@ -71,21 +72,24 @@ const LandingPageServiceTour: React.FC<PropsWithChildren> = () => {
   ];
 
   return (
-    <Joyride
-      callback={handleJoyrideCallback}
-      continuous
-      hideCloseButton
-      stepIndex={stepIndex}
-      run={isRunning}
-      showSkipButton
-      steps={steps}
-      styles={{
-        buttonNext: {
-          backgroundColor: `${theme.colors.point.primary.default}`,
-          color: 'white',
-        },
-      }}
-    />
+    <>
+      <Joyride
+        callback={handleJoyrideCallback}
+        continuous
+        hideCloseButton
+        stepIndex={stepIndex}
+        run={isRunning}
+        showSkipButton
+        steps={steps}
+        styles={{
+          buttonNext: {
+            backgroundColor: `${theme.colors.point.primary.default}`,
+            color: 'white',
+          },
+        }}
+      />
+      <ServiceTourNoticeDialog />
+    </>
   );
 };
 

--- a/src/components/landingPage/ServiceTourNoticeDialog.tsx
+++ b/src/components/landingPage/ServiceTourNoticeDialog.tsx
@@ -1,0 +1,85 @@
+import { Box, Button, Icon, Typography } from '@foundation/index';
+import { css, keyframes } from '@emotion/react';
+import { theme } from '@styles/theme';
+import { useEffect, useState } from 'react';
+import { runState } from '@atoms/serviceTour';
+import { useRecoilState } from 'recoil';
+
+const ShowDialog = keyframes`
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+`;
+
+const ServiceTourNoticeDialog = () => {
+  const [visible, setVisible] = useState(false);
+  const [{ isRunning: isRunning }, setInRunning] = useRecoilState(runState);
+
+  useEffect(() => {
+    if (!isRunning) {
+      setVisible(true);
+    } else {
+      setVisible(false);
+    }
+  }, [isRunning]);
+
+  if (!visible) return null;
+  return (
+    <Box
+      css={css`
+        position: fixed;
+        left: 1rem;
+        bottom: 1rem;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        row-gap: 0.5rem;
+        margin-right: 30rem;
+        padding: 0.5rem;
+        width: 15rem;
+        height: auto;
+
+        background-color: ${theme.colors.surface.default};
+        z-index: ${theme.zIndex.contentOverlay.overlay5};
+        animation: 1s cubic-bezier(0.5, 1.5, 0.5, 1) 0s 1 ${ShowDialog};
+      `}
+    >
+      <Button
+        variants="secondary"
+        size="sm"
+        onClick={() => setVisible(false)}
+        css={css`
+          position: absolute;
+          top: 0.5rem;
+          right: 0.5rem;
+          display: flex;
+          border: none;
+          z-index: ${theme.zIndex.contentOverlay.overlay5};
+        `}
+      >
+        <Icon id="close-black" />
+      </Button>
+      <div
+        css={css`
+          width: 100%;
+        `}
+      >
+        <Typography variant="body1">
+          <br />
+          아직 곰터뷰가 어려우신가요😂
+          <br />
+          튜토리얼을 통해서 곰터뷰에 <br />
+          익숙해지는건 어떨까요?
+        </Typography>
+      </div>
+      <Button size="sm" onClick={() => setInRunning({ isRunning: true })}>
+        튜토리얼 시작하기
+      </Button>
+    </Box>
+  );
+};
+
+export default ServiceTourNoticeDialog;

--- a/src/hooks/pages/Interview/useInterview.ts
+++ b/src/hooks/pages/Interview/useInterview.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { recordSetting } from '@/atoms/interviewSetting';
 import { localDownload, startRecording, stopRecording } from '@/utils/record';
 import { useUploadToIDrive } from '@/hooks/useUploadToIdrive';
@@ -8,6 +8,7 @@ import useInterviewFlow from '@hooks/pages/Interview/useInterviewFlow';
 import useInterviewSettings from '@/hooks/atoms/useInterviewSettings';
 import useMedia from '@hooks/useMedia';
 import useDevice from '@hooks/useDevice';
+import { recordingState } from '@atoms/interview';
 
 const useInterview = () => {
   const {
@@ -27,7 +28,8 @@ const useInterview = () => {
 
   const { selectedMimeType, selectedDevice } = useDevice();
 
-  const [isRecording, setIsRecording] = useState(false);
+  const [{ isRecording: isRecording }, setIsRecording] =
+    useRecoilState(recordingState);
   const [isScriptInView, setIsScriptInView] = useState(true);
   const [recordedBlobs, setRecordedBlobs] = useState<Blob[]>([]);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -46,15 +48,15 @@ const useInterview = () => {
       mediaRecorderRef,
       setRecordedBlobs,
     });
-    setIsRecording(true);
+    setIsRecording({ isRecording: true });
     startTimer();
-  }, [media, selectedMimeType, mediaRecorderRef, setRecordedBlobs, startTimer]);
+  }, [media, selectedMimeType, setIsRecording, startTimer]);
 
   const handleStopRecording = useCallback(() => {
     stopRecording(mediaRecorderRef);
-    setIsRecording(false);
+    setIsRecording({ isRecording: false });
     stopTimer();
-  }, [mediaRecorderRef, stopTimer]);
+  }, [setIsRecording, stopTimer]);
 
   const handleProcessing = useCallback(() => {
     if (recordedBlobs.length === 0 || isProcessing) {

--- a/src/page/LandingPage/index.tsx
+++ b/src/page/LandingPage/index.tsx
@@ -1,28 +1,34 @@
-import { StartButton } from '@common/index';
+import { ServiceTourStep, StartButton } from '@common/index';
 import {
   GoogleLoginButton,
   LandingImage,
   LandingPageLayout,
   WelcomeBlurb,
 } from '@components/landingPage';
+import LandingPageServiceTour from '@components/landingPage/LadingPageServiceTour';
 import { css } from '@emotion/react';
 
 const LandingPage: React.FC = () => {
   return (
-    <LandingPageLayout>
-      <WelcomeBlurb />
-      <div
-        css={css`
-          display: flex;
-          flex-direction: column;
-          row-gap: 2rem;
-        `}
-      >
-        <StartButton />
-        <GoogleLoginButton />
-      </div>
-      <LandingImage />
-    </LandingPageLayout>
+    <>
+      <LandingPageLayout>
+        <WelcomeBlurb />
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            row-gap: 2rem;
+          `}
+        >
+          <ServiceTourStep stepIndex={1}>
+            <StartButton />
+          </ServiceTourStep>
+          <GoogleLoginButton />
+        </div>
+        <LandingImage />
+      </LandingPageLayout>
+      <LandingPageServiceTour />
+    </>
   );
 };
 

--- a/src/page/interviewPage/index.tsx
+++ b/src/page/interviewPage/index.tsx
@@ -7,13 +7,15 @@ import {
   InterviewMain,
   InterviewFooter,
   InterviewPageLayout,
+  InterviewPageServiceTour,
 } from '@components/interviewPage';
 import {
   InterviewIntroModal,
   InterviewTimeOverModal,
 } from '@components/interviewPage/InterviewModal';
 import useInterview from '@/hooks/pages/Interview/useInterview';
-
+import { useRecoilState } from 'recoil';
+import { runState } from '@atoms/serviceTour';
 const InterviewPage: React.FC = () => {
   const {
     isAllSuccess,
@@ -32,6 +34,7 @@ const InterviewPage: React.FC = () => {
     setTimeOverModalIsOpen,
     reloadMedia,
   } = useInterview();
+  const [{ isRunning: isRunning }] = useRecoilState(runState);
 
   const [interviewIntroModalIsOpen, setInterviewIntroModalIsOpen] =
     useState<boolean>(true);
@@ -48,34 +51,37 @@ const InterviewPage: React.FC = () => {
     return <Navigate to={PATH.ROOT} />;
   } else
     return (
-      <InterviewPageLayout>
-        <InterviewHeader isRecording={isRecording} />
-        <InterviewMain
-          mirrorVideoRef={mirrorVideoRef}
-          isScriptInView={isScriptInView}
-          question={currentQuestion.questionContent}
-          answer={currentQuestion.answerContent}
-          connectStatus={connectStatus}
-          reloadMedia={reloadMedia}
-        />
-        <InterviewFooter
-          isRecording={isRecording}
-          recordedBlobs={recordedBlobs}
-          isLastQuestion={isLastQuestion}
-          handleStartRecording={handleStartRecording}
-          handleStopRecording={handleStopRecording}
-          handleScript={() => setIsScriptInView((prev) => !prev)}
-          handleNextQuestion={getNextQuestion}
-        />
-        <InterviewIntroModal
-          isOpen={interviewIntroModalIsOpen}
-          closeModal={() => setInterviewIntroModalIsOpen((prev) => !prev)}
-        />
-        <InterviewTimeOverModal
-          isOpen={timeOverModalIsOpen}
-          closeModal={() => setTimeOverModalIsOpen(false)}
-        />
-      </InterviewPageLayout>
+      <>
+        <InterviewPageLayout>
+          <InterviewHeader isRecording={isRecording} />
+          <InterviewMain
+            mirrorVideoRef={mirrorVideoRef}
+            isScriptInView={isScriptInView}
+            question={currentQuestion.questionContent}
+            answer={currentQuestion.answerContent}
+            connectStatus={connectStatus}
+            reloadMedia={reloadMedia}
+          />
+          <InterviewFooter
+            isRecording={isRecording}
+            recordedBlobs={recordedBlobs}
+            isLastQuestion={isLastQuestion}
+            handleStartRecording={handleStartRecording}
+            handleStopRecording={handleStopRecording}
+            handleScript={() => setIsScriptInView((prev) => !prev)}
+            handleNextQuestion={getNextQuestion}
+          />
+          <InterviewIntroModal
+            isOpen={!isRunning && interviewIntroModalIsOpen}
+            closeModal={() => setInterviewIntroModalIsOpen((prev) => !prev)}
+          />
+          <InterviewTimeOverModal
+            isOpen={timeOverModalIsOpen}
+            closeModal={() => setTimeOverModalIsOpen(false)}
+          />
+        </InterviewPageLayout>
+        <InterviewPageServiceTour />
+      </>
     );
 };
 

--- a/src/page/interviewSettingPage/QuestionSettingPage.tsx
+++ b/src/page/interviewSettingPage/QuestionSettingPage.tsx
@@ -3,6 +3,7 @@ import { QuestionSelectionBox } from '@common/index';
 import { useRecoilValue } from 'recoil';
 import InterviewSettingContentLayout from '@components/interviewSettingPage/InterviewSettingContentLayout';
 import NoticeDialog from '@common/QuestionSelectionBox/NoticeDialog/NoticeDialog';
+import { QuestionSelectPageServiceTour } from '@components/interviewSettingPage';
 
 type QuestionSettingPageProps = {
   onNextClick?: () => void;
@@ -25,6 +26,7 @@ const QuestionSettingPage: React.FC<QuestionSettingPageProps> = ({
       >
         <QuestionSelectionBox />
       </InterviewSettingContentLayout>
+      <QuestionSelectPageServiceTour />
     </>
   );
 };

--- a/src/page/interviewSettingPage/RecordSettingPage.tsx
+++ b/src/page/interviewSettingPage/RecordSettingPage.tsx
@@ -1,9 +1,14 @@
 import { RecordMethod, recordSetting } from '@/atoms/interviewSetting';
-import { Description, RecordRadio } from '@components/interviewSettingPage';
+import {
+  Description,
+  RecordPageServiceTour,
+  RecordRadio,
+} from '@components/interviewSettingPage';
 import { css } from '@emotion/react';
 import useUserInfo from '@hooks/useUserInfo';
 import { useRecoilState } from 'recoil';
 import InterviewSettingContentLayout from '@components/interviewSettingPage/InterviewSettingContentLayout';
+import { ServiceTourStep } from '@common/index';
 
 type RecordSettingPageProps = {
   onNextClick?: () => void;
@@ -24,69 +29,74 @@ const RecordSettingPage: React.FC<RecordSettingPageProps> = ({
   };
 
   return (
-    <InterviewSettingContentLayout
-      onPrevClick={onPrevClick}
-      onNextClick={onNextClick}
-      disabledNext={!setting.isSuccess}
-    >
-      <Description title="녹화 설정">
-        - 면접 시작 전, 사용하시는 장치의 화면 및 소리가 정상적으로 연결되어
-        있는지 확인해 주세요.
-        <br />
-        - 헤드셋이나 이어폰을 사용하시면 더욱 명료한 소리로 면접에 참여하실 수
-        있습니다.
-        <br />
-        - 화면이나 소리에 문제가 있을 경우, 잠시 면접을 중단하시고 문제를 해결한
-        뒤 이어나가 주세요.
-        <br />- 기타 기술적인 문제나 화면 공유 문제가 있으시면, 채팅창이나
-        연락처를 통해 알려주시길 바랍니다.
-      </Description>
-      {/* TODO: 엔터 인식해서 자동으로 줄바꿈 해주는 기능 추가 */}
-      <div
-        css={css`
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          flex-grow: 1;
-          width: 100%;
-        `}
+    <>
+      <InterviewSettingContentLayout
+        onPrevClick={onPrevClick}
+        onNextClick={onNextClick}
+        disabledNext={!setting.isSuccess}
       >
+        <Description title="녹화 설정">
+          - 면접 시작 전, 사용하시는 장치의 화면 및 소리가 정상적으로 연결되어
+          있는지 확인해 주세요.
+          <br />
+          - 헤드셋이나 이어폰을 사용하시면 더욱 명료한 소리로 면접에 참여하실 수
+          있습니다.
+          <br />
+          - 화면이나 소리에 문제가 있을 경우, 잠시 면접을 중단하시고 문제를
+          해결한 뒤 이어나가 주세요.
+          <br />- 기타 기술적인 문제나 화면 공유 문제가 있으시면, 채팅창이나
+          연락처를 통해 알려주시길 바랍니다.
+        </Description>
+        {/* TODO: 엔터 인식해서 자동으로 줄바꿈 해주는 기능 추가 */}
         <div
           css={css`
             display: flex;
-            flex-direction: column;
-            gap: 2rem;
-            width: 30rem;
+            justify-content: center;
+            align-items: center;
+            flex-grow: 1;
+            width: 100%;
           `}
         >
-          <RecordRadio
-            group="record"
-            IconId="save-idrive"
-            onChange={() => handleRecordChange('idrive')}
-            disabled={!userInfo}
-            defaultChecked={setting.method === 'idrive'}
+          <div
+            css={css`
+              display: flex;
+              flex-direction: column;
+              gap: 2rem;
+              width: 30rem;
+            `}
           >
-            서버에 저장
-          </RecordRadio>
-          <RecordRadio
-            group="record"
-            IconId="save-local"
-            onChange={() => handleRecordChange('local')}
-            defaultChecked={setting.method === 'local'}
-          >
-            로컬에 저장
-          </RecordRadio>
-          <RecordRadio
-            group="record"
-            IconId="save-not"
-            onChange={() => handleRecordChange('none')}
-            defaultChecked={setting.method === 'none'}
-          >
-            저장하지 않음
-          </RecordRadio>
+            <RecordRadio
+              group="record"
+              IconId="save-idrive"
+              onChange={() => handleRecordChange('idrive')}
+              disabled={!userInfo}
+              defaultChecked={setting.method === 'idrive'}
+            >
+              서버에 저장
+            </RecordRadio>
+            <ServiceTourStep stepIndex={0}>
+              <RecordRadio
+                group="record"
+                IconId="save-local"
+                onChange={() => handleRecordChange('local')}
+                defaultChecked={setting.method === 'local'}
+              >
+                로컬에 저장
+              </RecordRadio>
+            </ServiceTourStep>
+            <RecordRadio
+              group="record"
+              IconId="save-not"
+              onChange={() => handleRecordChange('none')}
+              defaultChecked={setting.method === 'none'}
+            >
+              저장하지 않음
+            </RecordRadio>
+          </div>
         </div>
-      </div>
-    </InterviewSettingContentLayout>
+      </InterviewSettingContentLayout>
+      <RecordPageServiceTour />
+    </>
   );
 };
 export default RecordSettingPage;

--- a/src/page/interviewSettingPage/ServiceTermsPage.tsx
+++ b/src/page/interviewSettingPage/ServiceTermsPage.tsx
@@ -1,8 +1,12 @@
 import { serviceTerms } from '@atoms/interviewSetting';
-import { Description } from '@components/interviewSettingPage';
+import {
+  Description,
+  TermPageServiceTour,
+} from '@components/interviewSettingPage';
 import { CheckBox } from '@foundation/index';
 import { useRecoilState } from 'recoil';
 import InterviewSettingContentLayout from '@components/interviewSettingPage/InterviewSettingContentLayout';
+import { ServiceTourStep } from '@common/index';
 
 type ServiceTermsPageProps = {
   onNextClick?: () => void;
@@ -21,32 +25,37 @@ const ServiceTermsPage: React.FC<ServiceTermsPageProps> = ({
       ...args,
     }));
   return (
-    <InterviewSettingContentLayout
-      onPrevClick={onPrevClick}
-      onNextClick={onNextClick}
-      disabledNext={!isSuccess}
-    >
-      <Description title="서비스 이용약관 동의">
-        본 서비스는 사용자의 면접 과정을 녹화해주는 서비스로 해당 과정을
-        촬영하기 위해서 카메라 및 음성에 대한 권한이 필요합니다.
-        <br />
-        사용자는 해당 권한을 통해 촬영된 영상을 직접 다운로드 받거나 서버에
-        저장하여 나중에 다시 볼 수 있습니다.
-        <br />
-        해당 녹화본은 사용자의 개인정보로서 외부에 공개되지 않으며, 사용자가
-        직접 공개하기 위해서는 별도의 공개 설정을 통해 공개할 수 있습니다.
-        <br />
-        참여자는 해당 약관에 대해서 거부할 수 있지만 거부시에 해당 서비스를
-        이용하지 못합니다.
-      </Description>
-      <CheckBox
-        id="terms-checkbox"
-        checked={isSuccess}
-        onInputChange={toggleIsChecked}
+    <>
+      <InterviewSettingContentLayout
+        onPrevClick={onPrevClick}
+        onNextClick={onNextClick}
+        disabledNext={!isSuccess}
       >
-        동의 하시겠습니까?
-      </CheckBox>
-    </InterviewSettingContentLayout>
+        <Description title="서비스 이용약관 동의">
+          본 서비스는 사용자의 면접 과정을 녹화해주는 서비스로 해당 과정을
+          촬영하기 위해서 카메라 및 음성에 대한 권한이 필요합니다.
+          <br />
+          사용자는 해당 권한을 통해 촬영된 영상을 직접 다운로드 받거나 서버에
+          저장하여 나중에 다시 볼 수 있습니다.
+          <br />
+          해당 녹화본은 사용자의 개인정보로서 외부에 공개되지 않으며, 사용자가
+          직접 공개하기 위해서는 별도의 공개 설정을 통해 공개할 수 있습니다.
+          <br />
+          참여자는 해당 약관에 대해서 거부할 수 있지만 거부시에 해당 서비스를
+          이용하지 못합니다.
+        </Description>
+        <ServiceTourStep stepIndex={0}>
+          <CheckBox
+            id="terms-checkbox"
+            checked={isSuccess}
+            onInputChange={toggleIsChecked}
+          >
+            동의 하시겠습니까?
+          </CheckBox>
+        </ServiceTourStep>
+      </InterviewSettingContentLayout>
+      <TermPageServiceTour />
+    </>
   );
 };
 

--- a/src/page/interviewSettingPage/VideoSettingPage.tsx
+++ b/src/page/interviewSettingPage/VideoSettingPage.tsx
@@ -1,6 +1,6 @@
 import { videoSetting } from '@/atoms/interviewSetting';
 import { theme } from '@/styles/theme';
-import { Mirror } from '@common/index';
+import { Mirror, ServiceTourStep } from '@common/index';
 import { RecordStatus } from '@components/interviewPage/InterviewHeader';
 import { Description } from '@components/interviewSettingPage';
 import { css } from '@emotion/react';
@@ -11,6 +11,7 @@ import useMedia from '@hooks/useMedia';
 import AudioSelectMenu from '@components/interviewSettingPage/VideoSettingPage/AudioSelectMenu';
 import VideoSelectMenu from '@components/interviewSettingPage/VideoSettingPage/VideoSelectMenu';
 import useDevice from '@hooks/useDevice';
+import VideoSettingPageServiceTour from '@components/interviewSettingPage/ServiceTour/VideoSettingPageServiceTour';
 
 type VideoSettingPageProps = {
   onNextClick?: () => void;
@@ -52,63 +53,70 @@ const VideoSettingPage: React.FC<VideoSettingPageProps> = ({
   }, [connectStatus, setVideoSettingState]);
 
   return (
-    <InterviewSettingContentLayout
-      onPrevClick={onPrevClick}
-      onNextClick={onNextClick}
-      disabledNext={!videoSettingState.isSuccess}
-    >
-      <Description title="문제 선택">
-        - 면접 시작 전, 사용하시는 장치의 화면 및 소리가 정상적으로 연결되어
-        있는지 확인해 주세요.
-        <br />
-        - 헤드셋이나 이어폰을 사용하시면 더욱 명료한 소리로 면접에 참여하실 수
-        있습니다.
-        <br />
-        - 화면이나 소리에 문제가 있을 경우, 잠시 면접을 중단하시고 문제를 해결한
-        뒤 이어나가 주세요.
-        <br />- 기타 기술적인 문제나 화면 공유 문제가 있으시면, 채팅창이나
-        연락처를 통해 알려주시길 바랍니다.
-      </Description>
-      <div
-        css={css`
-          position: relative;
-        `}
+    <>
+      <InterviewSettingContentLayout
+        onPrevClick={onPrevClick}
+        onNextClick={onNextClick}
+        disabledNext={!videoSettingState.isSuccess}
       >
+        <Description title="문제 선택">
+          - 면접 시작 전, 사용하시는 장치의 화면 및 소리가 정상적으로 연결되어
+          있는지 확인해 주세요.
+          <br />
+          - 헤드셋이나 이어폰을 사용하시면 더욱 명료한 소리로 면접에 참여하실 수
+          있습니다.
+          <br />
+          - 화면이나 소리에 문제가 있을 경우, 잠시 면접을 중단하시고 문제를
+          해결한 뒤 이어나가 주세요.
+          <br />- 기타 기술적인 문제나 화면 공유 문제가 있으시면, 채팅창이나
+          연락처를 통해 알려주시길 바랍니다.
+        </Description>
         <div
           css={css`
-            position: absolute;
-            top: 1rem;
-            left: 1rem;
-            z-index: ${theme.zIndex.contentOverlay.overlay5};
-            padding: 0.5rem;
-            border-radius: 0.5rem;
-            background-color: ${theme.colors.shadow.modalShadow};
+            position: relative;
           `}
         >
-          <RecordStatus isRecording={connectStatus === 'connect'} />
+          <div
+            css={css`
+              position: absolute;
+              top: 1rem;
+              left: 1rem;
+              z-index: ${theme.zIndex.contentOverlay.overlay5};
+              padding: 0.5rem;
+              border-radius: 0.5rem;
+              background-color: ${theme.colors.shadow.modalShadow};
+            `}
+          >
+            <RecordStatus isRecording={connectStatus === 'connect'} />
+          </div>
+          <ServiceTourStep stepIndex={1}>
+            <Mirror
+              mirrorVideoRef={mirrorVideoRef}
+              connectStatus={connectStatus}
+              reloadMedia={() =>
+                void startMedia({
+                  audioDeviceId: selectedDevice.audioInput?.deviceId,
+                  videoDeviceId: selectedDevice.video?.deviceId,
+                })
+              }
+              isSetting
+            />
+          </ServiceTourStep>
+          <div
+            css={css`
+              display: flex;
+              justify-content: center;
+              gap: 1rem;
+              margin: 2.5rem 0rem;
+            `}
+          >
+            <AudioSelectMenu />
+            <VideoSelectMenu />
+          </div>
         </div>
-        <Mirror
-          mirrorVideoRef={mirrorVideoRef}
-          connectStatus={connectStatus}
-          reloadMedia={() =>
-            void startMedia({
-              audioDeviceId: selectedDevice.audioInput?.deviceId,
-              videoDeviceId: selectedDevice.video?.deviceId,
-            })
-          }
-          isSetting
-        />
-        <div
-          css={css`
-            display: flex;
-            gap: 0.5rem;
-          `}
-        >
-          <AudioSelectMenu />
-          <VideoSelectMenu />
-        </div>
-      </div>
-    </InterviewSettingContentLayout>
+      </InterviewSettingContentLayout>
+      <VideoSettingPageServiceTour />
+    </>
   );
 };
 

--- a/src/styles/_global.ts
+++ b/src/styles/_global.ts
@@ -132,6 +132,11 @@ const _global = css`
     border-spacing: 0;
   }
 
+  .react-joyride__spotlight {
+    opacity: 0.3 !important; /* 현재 페이지 별로 다른 css가 들어감으로 인한 임시조치 joyride 내부 문제로 확인*/
+    background-color: white !important;
+  }
+
   * {
     box-sizing: border-box;
   }


### PR DESCRIPTION
[![NDD-411](https://badgen.net/badge/JIRA/NDD-411/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-411) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

서비스 진입시에 불친절하던 기존 로직을 Service Tour를 도입하며 해결합니다.

# How

ServiceTour 로직에 대해서 간단하게 설명하도록 하겠습니다. 
### 1 Layout => 1 ServiceTour
<img width="318" alt="image" src="https://github.com/the-NDD/Gomterview-FE/assets/77886826/f87b1bb8-af14-4faa-952c-9674308a1e88">

현재는 ServiceTour 로직을 모든 페이지를 감싸서 실행시키는 것이 아닌 페이지 별로 각기 다른 ServiceTour 컴포넌트가 선언되어 있습니다.
그 이유는 곰터뷰 서비스가 가지는 특징과도 연결되어있습니다. 해당 ServiceTour로직은 곰터뷰의 Interview flow 전체를 수행합니다. 

그에 따라 모든 로직을 감싸서 ServiceTour 로직을 개발하게 되면, 해당 컴포넌트의 책임이 과하게 커지게 됩니다. 
ServiceTour 중 특정 페이지의 Tour를 수정하려 하는데, 이때 모든 Tour를 하나의 컴포넌트가 책임을 지게 되면 불가피한 사이드 이펙트가 발생할 확률이 과하게 높습니다. 

그에 따라 1 Layout => 1 ServiceTour  로 해결합니다. 

그렇다면? 각기 다른 ServiceTour의 연결은 어떻게 관리하면 좋을까요? 

여러 방식이 있었지만 가장 읽기 쉬운 구조로 관리하기로 했습니다.

```js
// ServiceTour의 on-off 를 담당하는 isRunning 을 전역으로 관리합니다.
// 
const [{ isRunning: isRunning }, setInRunning] = useRecoilState(runState);

... 
...

return (
    <Joyride
      ...
      run={isRunning} // 각기 다른 컴포넌트 에서도 해당 전역변수를 통해서 관리합니다
      ...
    />
  );

```

그렇다면 해당 하나의 Layout에서 정의하여 실행한 ServiceTour가 다른 페이지의 ServiceTour 동작에는 딱하나의 전역변수인 isRunning 으로만 연결된 거의 dependency가 없는 상태임을 확인했습니다.

그렇다면 해당 ServiceTour가 Layout에 영향을 주는 것을 확인해보겠습니다.

## Step의 target을 통해 Dom에 접근
<img width="551" alt="image" src="https://github.com/the-NDD/Gomterview-FE/assets/77886826/fbc48e5f-4e33-4167-96ad-cf5d06964cf9">
해당 사진을 보면 step 객체에 대한 각 선언이 적혀 있습니다. 여기선 target 에 집중하면 됩니다.

오로지 여기서 target만이 Dom, 즉 우리의 서비스와 연결되어 있습니다. 즉 우리의 서비스에 target을 찾을 수 있게끔 설정만 해두면 됩니다!

<img width="417" alt="image" src="https://github.com/the-NDD/Gomterview-FE/assets/77886826/3653da46-22b2-431b-a432-a74d9f7e48f2">

연결방법은 아주 쉽습니다! 우리가 target으로 설정하고 싶은 컴포넌트를 제 ServiceTourStep으로 감싸주고 특정 index만 추가해주면 됩니다!

# To Reviewer
주의할 점에 대해서 작성합니다.

1. 해당 ServiceTour는 항상, Landing 페이지에서만 실행합니다.
2. skip 버튼을 클릭시 만 하루가 지나야 다시 해당 tutorial을 트리거 합니다.
3. 페이지의 특정 이벤트(예를들어 녹화 여부, 문제 선택 여부)에 접근하기 위해선 전역으로 관리되는 상태들이 존재해야만 합니다. 하지만 우린 이미 만들어놔서 아주아주 연결하기 쉬웠네요!