### PR TITLE
[NDD-415] 중복되는 UI 수정 (3h/3h)

### DIFF
--- a/src/components/foundation/Button/Button.styles.ts
+++ b/src/components/foundation/Button/Button.styles.ts
@@ -42,7 +42,8 @@ export const buttonVariants = {
     border: 1px solid ${theme.colors.border.default};
 
     &:disabled {
-      background-color: ${theme.colors.surface.weakHover};
+      background-color: ${theme.colors.text.white};
+      color: ${theme.colors.surface.weak};
       cursor: not-allowed;
     }
 

--- a/src/components/foundation/Button/Button.tsx
+++ b/src/components/foundation/Button/Button.tsx
@@ -22,7 +22,7 @@ const Button: React.FC<ButtonProps> = ({
     <button
       css={[
         css`
-          transition: background-color 0.15s ease-in-out;
+          transition: all 0.15s ease-in-out;
           cursor: pointer;
         `,
         buttonSize[size],

--- a/src/components/foundation/SelectionBox/SelectionBox.tsx
+++ b/src/components/foundation/SelectionBox/SelectionBox.tsx
@@ -40,6 +40,10 @@ const SelectionBox: React.FC<SelectionButtonProps> = ({
             ${selectionBoxDirection[lineDirection]}
             color: ${theme.colors.text.default};
           }
+          &:hover:not(:checked) + label {
+            color: ${theme.colors.text.sub};
+            cursor: pointer;
+          }
         `}
       />
       <label

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -37,7 +37,7 @@ const Header: React.FC = () => {
         css={css`
           display: none;
           @media (min-width: ${theme.breakpoints.tablet}) {
-            display: block;
+            display: flex;
           }
         `}
       >

--- a/src/components/layout/Header/Navigations.tsx
+++ b/src/components/layout/Header/Navigations.tsx
@@ -35,12 +35,13 @@ const Navigations: React.FC = () => {
       {navigationList.map(
         (item) =>
           item.visibility && (
-            <MenuItem key={item.path}>
-              <Tooltip
-                title={item.message}
-                position="bottom"
-                disabled={!item.message}
-              >
+            <Tooltip
+              title={item.message}
+              position="bottom"
+              disabled={!item.message}
+              key={item.path}
+            >
+              <MenuItem>
                 <Link
                   to={item.path}
                   css={css`
@@ -54,8 +55,8 @@ const Navigations: React.FC = () => {
                     {item.text}
                   </Typography>
                 </Link>
-              </Tooltip>
-            </MenuItem>
+              </MenuItem>
+            </Tooltip>
           )
       )}
       {!isLogin && (

--- a/src/components/layout/Header/Navigations.tsx
+++ b/src/components/layout/Header/Navigations.tsx
@@ -41,21 +41,21 @@ const Navigations: React.FC = () => {
               disabled={!item.message}
               key={item.path}
             >
-              <MenuItem>
-                <Link
-                  to={item.path}
-                  css={css`
-                    text-decoration: none;
-                  `}
-                >
+              <Link
+                to={item.path}
+                css={css`
+                  text-decoration: none;
+                `}
+              >
+                <MenuItem>
                   <Typography
                     variant="body1"
                     color={theme.colors.text.subStrong}
                   >
                     {item.text}
                   </Typography>
-                </Link>
-              </MenuItem>
+                </MenuItem>
+              </Link>
             </Tooltip>
           )
       )}

--- a/src/components/layout/Header/Navigations.tsx
+++ b/src/components/layout/Header/Navigations.tsx
@@ -18,7 +18,7 @@ const Navigations: React.FC = () => {
     },
     {
       path: PATH.INTERVIEW_SETTING,
-      text: '면접 문제 풀러가기',
+      text: '면접 연습 시작하기',
       visibility: true,
       message: '원하는 질문을 선택해 면접 연습을 시작해보세요!',
     },

--- a/src/components/myPage/MyPageHeader.tsx
+++ b/src/components/myPage/MyPageHeader.tsx
@@ -1,7 +1,5 @@
-import { PATH } from '@constants/path';
 import { css } from '@emotion/react';
-import { Typography, Button, Tooltip } from '@foundation/index';
-import { Link } from 'react-router-dom';
+import { Typography } from '@foundation/index';
 
 const MyPageHeader: React.FC = () => {
   return (
@@ -13,11 +11,6 @@ const MyPageHeader: React.FC = () => {
       `}
     >
       <Typography variant="title1">마이페이지</Typography>
-      <Tooltip title="원하는 질문을 선택해 면접을 연습해보세요">
-        <Link to={PATH.INTERVIEW_SETTING}>
-          <Button size="md">면접 시작하기</Button>
-        </Link>
-      </Tooltip>
     </div>
   );
 };

--- a/src/page/WorkbookDetailPage/index.tsx
+++ b/src/page/WorkbookDetailPage/index.tsx
@@ -72,7 +72,6 @@ const WorkbookDetailPage = () => {
     setSelectedQuestion(
       questionWorkbookData?.map((question) => question) || []
     );
-    toast.success('모든 질문이 선택 되었습니다.');
   };
 
   const allUnSelectQuestion = () => setSelectedQuestion([]);
@@ -82,7 +81,7 @@ const WorkbookDetailPage = () => {
     setAllSelected((prev) => !prev);
   };
 
-  const validateAddWorkbookListModal = () => {
+  const validateAddWorkbookList = () => {
     if (!userInfo) {
       toast.warning('로그인이 필요합니다.');
       return false;
@@ -133,13 +132,15 @@ const WorkbookDetailPage = () => {
           >
             <Button
               variants="secondary"
+              disabled={selectedQuestion.length < 1}
               onClick={openStartWithSelectedQuestionModal}
             >
-              인터뷰 시작하기
+              면접 시작하기
             </Button>
             <Button
+              disabled={selectedQuestion.length < 1}
               onClick={() => {
-                validateAddWorkbookListModal() && openAddWorkbookListModal();
+                validateAddWorkbookList() && openAddWorkbookListModal();
               }}
             >
               질문 가져오기


### PR DESCRIPTION
[![NDD-415](https://badgen.net/badge/JIRA/NDD-415/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-415) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

자잘자잘한 변경사항들이 있습니다 구조적으로 큰 변화는 없습니다. (UI/UX향상!!)

# Result

<img width="974" alt="image" src="https://github.com/the-NDD/Gomterview-FE/assets/49224104/dafb2cea-2e7b-4f98-b957-a7bb0c6ee270">

- 이제 버튼의 바깥 부분을 hover해도 tooltip 및 클릭했을 때 이동이 가능합니다.

<br/>


<img width="119" alt="image" src="https://github.com/the-NDD/Gomterview-FE/assets/49224104/e08770ef-473d-4993-94b0-9485e5586497">

- selectionBox를 hover했을때 반응을 추가하였습니다


<br/>

<img width="672" alt="image" src="https://github.com/the-NDD/Gomterview-FE/assets/49224104/724665c4-3839-4759-afb5-13932c998bf3">
<img width="659" alt="image" src="https://github.com/the-NDD/Gomterview-FE/assets/49224104/8b0aedde-a66b-4125-8a4a-e412a8e3b889">

- 디테일 페이지에서 질문들을 선택했을시에만 버튼이 활성화 되도록 설정하였습니다. 
- 버튼의 텍스트를 인터뷰 시작하기에서 면접
 시작하기로 변경하였습니다.
=> 모든 서비스내에 텍스트를 면접으로 통일하고자 합니다

<img width="971" alt="image" src="https://github.com/the-NDD/Gomterview-FE/assets/49224104/5487868b-072a-4ce6-8e35-46308d7824fd">

- header에 있는 navigation과 중복이 되어 마이페이지에 있는 면접 시작하기 버튼을 삭제하였습니다.  
- 면접문제 풀러가기에서 면접 연습 시작하기로 텍스트를 변경하였습니다

[NDD-415]: https://milk717.atlassian.net/browse/NDD-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ