### PR TITLE
[NDD-418] 메인페이지에 면접 영상 바로보러가기 tooltip 깜빡임 추가 (1h/2h)

### DIFF
--- a/src/components/foundation/Tooltip/Tooltip.styles.ts
+++ b/src/components/foundation/Tooltip/Tooltip.styles.ts
@@ -2,35 +2,27 @@ import { css } from '@emotion/react';
 
 export const positionStyles = {
   top: css`
-    &:hover > :first-child {
-      top: 0;
-      left: 50%;
-      transform: translate(-50%, -100%);
-      margin-top: -0.5rem;
-    }
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -100%);
+    margin-top: -0.5rem;
   `,
   bottom: css`
-    &:hover > :first-child {
-      top: 100%;
-      left: 50%;
-      transform: translate(-50%, 0);
-      margin-top: 0.5rem;
-    }
+    top: 100%;
+    left: 50%;
+    transform: translate(-50%, 0);
+    margin-top: 0.5rem;
   `,
   left: css`
-    &:hover > :first-child {
-      top: 50%;
-      left: 0;
-      transform: translate(-100%, -50%);
-      margin-left: -0.5rem;
-    }
+    top: 50%;
+    left: 0;
+    transform: translate(-100%, -50%);
+    margin-left: -0.5rem;
   `,
   right: css`
-    &:hover > :first-child {
-      top: 50%;
-      left: 100%;
-      transform: translate(0, -50%);
-      margin-left: 0.5rem;
-    }
+    top: 50%;
+    left: 100%;
+    transform: translate(0, -50%);
+    margin-left: 0.5rem;
   `,
 } as const;

--- a/src/components/foundation/Tooltip/Tooltip.tsx
+++ b/src/components/foundation/Tooltip/Tooltip.tsx
@@ -13,11 +13,27 @@ const fadeIn = keyframes`
   }
 `;
 
+const blink = keyframes`
+  0% {
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+`;
+
 type TooltipProps = {
   children: React.ReactNode;
   title: string;
   position?: 'top' | 'bottom' | 'left' | 'right';
   disabled?: boolean;
+  blinkInterval?: number;
 };
 
 const Tooltip: React.FC<TooltipProps> = ({
@@ -25,34 +41,37 @@ const Tooltip: React.FC<TooltipProps> = ({
   children,
   position = 'top',
   disabled = false,
+  blinkInterval,
 }) => {
+  const animationDuration = blinkInterval ? `${blinkInterval / 1000}s` : '0s';
+
   return (
     <div
-      css={[
-        css`
-          position: relative;
-
-          &:hover > :first-child {
+      css={css`
+        position: relative;
+        &:hover > :first-child {
+          display: ${!disabled && 'block'};
+          animation: ${fadeIn} 0.2s linear;
+        }
+      `}
+    >
+      <Typography
+        variant="body3"
+        noWrap
+        css={[
+          css`
+            display: ${blinkInterval ? 'block' : 'none'};
             position: absolute;
             padding: 0.3rem 0.5rem;
             background-color: ${theme.colors.surface.tooltip};
 
             color: ${theme.colors.text.white};
             border-radius: 0.5rem;
-            display: ${!disabled && 'block'};
             z-index: ${theme.zIndex.tooltip.content};
-          }
-        `,
-        positionStyles[position],
-      ]}
-    >
-      <Typography
-        variant="body3"
-        noWrap
-        css={css`
-          display: none;
-          animation: ${fadeIn} 0.2s linear;
-        `}
+            animation: ${blink} ${animationDuration} infinite;
+          `,
+          positionStyles[position],
+        ]}
       >
         {title}
       </Typography>

--- a/src/components/layout/Header/Navigations.tsx
+++ b/src/components/layout/Header/Navigations.tsx
@@ -4,7 +4,7 @@ import { theme } from '@styles/theme';
 import { PATH } from '@constants/path';
 import useUserInfo from '@hooks/useUserInfo';
 import redirectToGoogleLogin from '@/utils/redirectToGoogleLogin';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Tooltip } from '@foundation/index';
 import { useErrorBoundary } from 'react-error-boundary';
 
@@ -38,18 +38,26 @@ const Navigations: React.FC = () => {
     },
   ];
 
-  const { resetBoundary } = useErrorBoundary(); // 가정: 에러 바운더리 리셋 함수를 제공
+  const { resetBoundary } = useErrorBoundary();
+  const location = useLocation();
 
   return (
     <>
       {navigationList.map(
-        (item) =>
+        (item, index) =>
           item.visibility && (
             <Tooltip
               title={item.message}
               position="bottom"
               disabled={!item.message}
               key={item.path}
+              blinkInterval={
+                index === 0 && location.pathname === PATH.ROOT
+                  ? 5000
+                  : undefined
+              }
+              // 면접 영상 보러가기의 tooltip은 5초 간격으로 깜빡이도록 설정
+              // TODO: 추후 분리할때 로직 변경 필요 현재는 index로 구분
             >
               <Link
                 to={item.path}


### PR DESCRIPTION
[![NDD-418](https://badgen.net/badge/JIRA/NDD-418/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-418) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

css로 해결하려고 해서 약간 시간이 걸렸습니다. props로 ms단위로 값을 넘겨주고 있습니다

# How

css animation을 이용해서 깜빡이면서 보여주는걸 처리했습니다.
일단 코드 자체가 길게 사용할 일 없을 것이라 판단하고 navigations 컴포넌트에서 각각의 메뉴들을 index로 찾아서 사용하였습니다. 추후에 더 커지면 분리가 필요합니다.