### PR TITLE
[NDD-435] useModal 버그 수정 및 패키지 정리 (3h/4h)

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -3649,7 +3649,7 @@ const RAW_RUNTIME_STATE =
           ["@rollup/plugin-node-resolve", "virtual:6c5b5d9cc4ba1e90e27d651e705664ab355e30fbe411b77fc89154cb06078a7441523bfc214849048458f0f867118a97664789e852065d1429b02cd7dd91fcb8#npm:15.2.3"],\
           ["@testing-library/dom", "npm:10.0.0"],\
           ["@testing-library/jest-dom", "virtual:6c5b5d9cc4ba1e90e27d651e705664ab355e30fbe411b77fc89154cb06078a7441523bfc214849048458f0f867118a97664789e852065d1429b02cd7dd91fcb8#npm:6.4.2"],\
-          ["@testing-library/react", "virtual:f025dd47b60e50d448d544af28436b3fd28793369291bdb08ba317b8456969dc38457ee55a327a0976a92ad33c2e257ed3535dec9c4dae23c03623fc4dd61552#npm:15.0.2"],\
+          ["@testing-library/react", "virtual:6c5b5d9cc4ba1e90e27d651e705664ab355e30fbe411b77fc89154cb06078a7441523bfc214849048458f0f867118a97664789e852065d1429b02cd7dd91fcb8#npm:15.0.2"],\
           ["@testing-library/user-event", "virtual:6c5b5d9cc4ba1e90e27d651e705664ab355e30fbe411b77fc89154cb06078a7441523bfc214849048458f0f867118a97664789e852065d1429b02cd7dd91fcb8#npm:14.5.2"],\
           ["@types/jest", "npm:29.5.12"],\
           ["@types/react", "npm:18.2.64"],\
@@ -3657,6 +3657,7 @@ const RAW_RUNTIME_STATE =
           ["babel-jest", "virtual:6c5b5d9cc4ba1e90e27d651e705664ab355e30fbe411b77fc89154cb06078a7441523bfc214849048458f0f867118a97664789e852065d1429b02cd7dd91fcb8#npm:29.7.0"],\
           ["jest", "virtual:6c5b5d9cc4ba1e90e27d651e705664ab355e30fbe411b77fc89154cb06078a7441523bfc214849048458f0f867118a97664789e852065d1429b02cd7dd91fcb8#npm:29.7.0"],\
           ["jest-environment-jsdom", "virtual:6c5b5d9cc4ba1e90e27d651e705664ab355e30fbe411b77fc89154cb06078a7441523bfc214849048458f0f867118a97664789e852065d1429b02cd7dd91fcb8#npm:29.7.0"],\
+          ["react", "npm:18.2.0"],\
           ["rollup", "npm:4.16.4"],\
           ["rollup-plugin-dts", "virtual:6c5b5d9cc4ba1e90e27d651e705664ab355e30fbe411b77fc89154cb06078a7441523bfc214849048458f0f867118a97664789e852065d1429b02cd7dd91fcb8#npm:6.1.0"],\
           ["typescript", "patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>::version=5.4.2&hash=5adc0c"]\
@@ -5169,25 +5170,6 @@ const RAW_RUNTIME_STATE =
           ["@types/react", "npm:18.2.64"],\
           ["@types/react-dom", "npm:18.2.25"],\
           ["react", "npm:18.2.0"],\
-          ["react-dom", null]\
-        ],\
-        "packagePeers": [\
-          "@types/react-dom",\
-          "@types/react",\
-          "react-dom",\
-          "react"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:f025dd47b60e50d448d544af28436b3fd28793369291bdb08ba317b8456969dc38457ee55a327a0976a92ad33c2e257ed3535dec9c4dae23c03623fc4dd61552#npm:15.0.2", {\
-        "packageLocation": "./.yarn/__virtual__/@testing-library-react-virtual-ffeee9c452/0/cache/@testing-library-react-npm-15.0.2-095a436fff-8d75e4850f.zip/node_modules/@testing-library/react/",\
-        "packageDependencies": [\
-          ["@testing-library/react", "virtual:f025dd47b60e50d448d544af28436b3fd28793369291bdb08ba317b8456969dc38457ee55a327a0976a92ad33c2e257ed3535dec9c4dae23c03623fc4dd61552#npm:15.0.2"],\
-          ["@babel/runtime", "npm:7.24.0"],\
-          ["@testing-library/dom", "npm:10.0.0"],\
-          ["@types/react", "npm:18.2.64"],\
-          ["@types/react-dom", "npm:18.2.25"],\
-          ["react", null],\
           ["react-dom", null]\
         ],\
         "packagePeers": [\

--- a/packages/useModal/README.md
+++ b/packages/useModal/README.md
@@ -2,6 +2,8 @@
 
 Allows modal components to be used without dependency on JSX.
 
+You can use codesandbox to see the example [here](https://codesandbox.io/p/sandbox/usemodal-ktv8ws)
+
 ## Example
 
 Modal is even better when used with the Compound Component pattern

--- a/packages/useModal/package.json
+++ b/packages/useModal/package.json
@@ -51,6 +51,7 @@
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "react": "^18.2.0",
     "rollup": "^4.16.4",
     "rollup-plugin-dts": "^6.1.0",
     "typescript": "^5.3.3"

--- a/packages/useModal/package.json
+++ b/packages/useModal/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc --emitDeclarationOnly --outDir ./dist/types && rollup --config && rm -rf ./types"
+    "build": "tsc -p tsconfig.build.json && rollup --config && rm -rf ./types"
   },
   "devDependencies": {
     "@babel/core": "^7.24.4",

--- a/packages/useModal/package.json
+++ b/packages/useModal/package.json
@@ -4,7 +4,7 @@
   "exports": "./src/index.ts",
   "description": "react custom hook for modal",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "react",
     "hook",

--- a/packages/useModal/rollup.config.js
+++ b/packages/useModal/rollup.config.js
@@ -23,6 +23,7 @@ module.exports = [
       commonjs(),
       babel({ extensions, babelHelpers: 'bundled' }),
     ],
+    external: ['react', 'react-dom'],
   },
   {
     input: 'types/index.d.ts',

--- a/packages/useModal/src/index.test.tsx
+++ b/packages/useModal/src/index.test.tsx
@@ -83,6 +83,25 @@ describe('useModal의 기본 동작 테스트', () => {
     // assert: 테스트 결과 확인
     expect(screen.queryByText('Test Modal')).not.toBeInTheDocument();
   });
+  it('openModal을 여러번 호출해도 Modal은 하나만 랜더링 된다.', async () => {
+    //arrange: 테스트 환경 구성
+    const user = userEvent.setup();
+
+    // act: dom에 컴포넌트 랜더링
+    renderWithModalProvider(<TestComponent />);
+    const openButton = await screen.findByText('open');
+    await user.click(openButton);
+    await user.click(openButton);
+    await user.click(openButton);
+    await user.click(openButton);
+    await user.click(openButton);
+    await user.click(openButton);
+
+    const modals = screen.getAllByText('Test Modal');
+
+    // assert: 테스트 결과 확인
+    expect(modals).toHaveLength(1);
+  });
 });
 
 describe('useModal 추가 동작 테스트', () => {

--- a/packages/useModal/src/useModal.ts
+++ b/packages/useModal/src/useModal.ts
@@ -10,10 +10,11 @@ const useModal = (component: React.FC) => {
   const id = useId();
 
   const openModal = useCallback(() => {
+    if (isOpen) return;
     setIsOpen(true);
     setModalElements((pre) => [...pre, { id: id, element: component }]);
     document.body.style.overflow = 'hidden';
-  }, [component, id, setModalElements]);
+  }, [component, id, isOpen, setModalElements]);
 
   const closeModal = useCallback(() => {
     setIsOpen(false);

--- a/packages/useModal/tsconfig.build.json
+++ b/packages/useModal/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.build.json",
   "compilerOptions": {
-    "isolatedModules": true,
     "noEmit": false,
     "emitDeclarationOnly": true,
     "declaration": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "exclude": ["**/*.test.*", "**/*.spec.*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,6 +2101,7 @@ __metadata:
     babel-jest: "npm:^29.7.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
+    react: "npm:^18.2.0"
     rollup: "npm:^4.16.4"
     rollup-plugin-dts: "npm:^6.1.0"
     typescript: "npm:^5.3.3"


### PR DESCRIPTION
[![NDD-435](https://badgen.net/badge/JIRA/NDD-435/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-435) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

openModal을 여러번 하는 경우 발생하는 에러를 해결하는게 주된 PR이었습니다.

# How
- 빌드와 테스트 코드에 대한 환경을 따로 세팅 하였습니다.
- protal을 설정해 주자는 기존 option은 랜더링 문제로 아이디어를 삭제 하였습니다.
   - provider 내부에서 portal을 사용하고 children 컴포넌트 내부에 있는 컴포넌트로 portal을 사용하기 때문에 초기에 props로 받아올때는 값이 없는 문제가 있습니다.
- codesandbox를 추가하였습니다.

# Result
![image](https://github.com/the-NDD/Gomterview-FE/assets/49224104/f94dc8a2-34b9-4401-a542-0c7563b8daf2)

### 사용 할수 있는 codesandbox 추가
https://codesandbox.io/p/sandbox/usemodal-ktv8ws?file=/src/App.js:13,11